### PR TITLE
feat: add posthog-analytics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ After installation, see all your available skills:
 | Skill | Description |
 |-------|-------------|
 | [create-skill](./skills/create-skill/SKILL.md) | Guide for creating AdaL skills - personal, project, or plugin |
+| [posthog-analytics](./skills/posthog-analytics/SKILL.md) | Automate PostHog dashboard creation, sync, and export via API |
 
 ## Creating Your Own Skills
 

--- a/skills/posthog-analytics/SKILL.md
+++ b/skills/posthog-analytics/SKILL.md
@@ -1,0 +1,147 @@
+# PostHog Analytics Skill
+
+Automate PostHog dashboard creation, sync, and export via API.
+
+## When to Use
+
+- Setting up analytics dashboards for new projects
+- Syncing dashboard configs between environments (add new insights without duplicates)
+- Exporting existing dashboards to version-controlled configs
+- Querying PostHog events programmatically
+
+## Prerequisites
+
+```bash
+# Required environment variable
+export POSTHOG_PERSONAL_API_KEY=phx_xxx  # Get from PostHog Settings → Personal API Keys
+```
+
+## Workflow
+
+### 1. Create New Dashboard
+```bash
+./scripts/posthog_sync.sh create examples/blog_dashboard.json
+```
+Creates dashboard + all insights. Updates config with `dashboard_id`.
+
+### 2. Sync Changes (Add New Insights)
+```bash
+# Edit config to add new insights, then:
+./scripts/posthog_sync.sh sync examples/app_dashboard.json
+```
+Only creates NEW insights. Existing ones are detected by name and skipped.
+
+### 3. Export Existing Dashboard
+```bash
+./scripts/posthog_sync.sh export 1126158 > my_dashboard.json
+```
+Exports dashboard with all insight names and IDs.
+
+## Config Schema
+
+```json
+{
+  "name": "Dashboard Name",
+  "description": "Description",
+  "domain_filter": "app.sylph.ai",
+  "dashboard_id": null,
+  "insights": [
+    {
+      "name": "Pageviews (Total)",
+      "type": "pageviews_total",
+      "display": "BoldNumber",
+      "date_range": "-30d"
+    }
+  ]
+}
+```
+
+### Insight Types
+
+| Type | Display | Math | Description |
+|------|---------|------|-------------|
+| `pageviews_total` | BoldNumber | total | Total pageview count |
+| `unique_users` | BoldNumber | dau | Daily unique users |
+| `traffic_trend` | ActionsLineGraph | total | Line chart over time |
+| `top_pages` | ActionsTable | total | Table with URL breakdown |
+| `custom` | Any | Any | Full control via params |
+
+### Math Options
+
+| Math | Description |
+|------|-------------|
+| `total` | Total count |
+| `dau` | Daily active users |
+| `weekly_active` | Weekly active users |
+| `monthly_active` | Monthly active users |
+
+### Display Options
+
+| Display | Description |
+|---------|-------------|
+| `BoldNumber` | Single large number |
+| `ActionsLineGraph` | Line chart |
+| `ActionsTable` | Table with breakdown |
+| `ActionsBar` | Vertical bar chart |
+
+## API Quick Reference
+
+```bash
+# List dashboards
+curl -H "Authorization: Bearer $KEY" "https://us.i.posthog.com/api/projects/@current/dashboards/"
+
+# Query events
+curl -H "Authorization: Bearer $KEY" "https://us.i.posthog.com/api/projects/@current/events?limit=100" | \
+  jq '.results[:5] | .[] | "\(.event) | \(.properties["$current_url"])"'
+
+# Filter events by domain
+curl -s -H "Authorization: Bearer $KEY" ".../events?limit=100" | \
+  jq '[.results[] | select(.properties["$current_url"] | contains("yourdomain"))] | length'
+```
+
+## Example Configs
+
+### Blog Analytics
+```json
+{
+  "name": "Blog Analytics",
+  "domain_filter": "blog.sylph.ai",
+  "insights": [
+    {"name": "Pageviews", "type": "pageviews_total"},
+    {"name": "Unique Readers", "type": "unique_users"},
+    {"name": "Traffic Trend", "type": "traffic_trend"},
+    {"name": "Top Posts", "type": "top_pages"}
+  ]
+}
+```
+
+### App Product Metrics
+```json
+{
+  "name": "App Product Metrics",
+  "domain_filter": "app.sylph.ai",
+  "insights": [
+    {"name": "DAU", "type": "unique_users"},
+    {"name": "WAU", "type": "unique_users", "math": "weekly_active"},
+    {"name": "Pageviews", "type": "pageviews_total"},
+    {"name": "Usage Trend", "type": "traffic_trend"},
+    {"name": "Top Pages", "type": "top_pages"}
+  ]
+}
+```
+
+## Files
+
+- `SKILL.md` - This guide
+- `dashboard_schema.json` - JSON schema for validation
+- `scripts/posthog_sync.sh` - Create/sync/export script
+- `examples/blog_dashboard.json` - Blog dashboard config
+- `examples/app_dashboard.json` - App dashboard config
+
+## References
+
+- [PostHog API Docs](https://posthog.com/docs/api) - Full API reference
+- [Insights API](https://posthog.com/docs/api/insights) - Creating/querying insights
+- [Dashboards API](https://posthog.com/docs/api/dashboards) - Dashboard management
+- [Events API](https://posthog.com/docs/api/events) - Event querying
+- [HogQL](https://posthog.com/docs/hogql) - PostHog query language for advanced queries

--- a/skills/posthog-analytics/dashboard_schema.json
+++ b/skills/posthog-analytics/dashboard_schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PostHog Dashboard Config",
+  "description": "Version-controlled dashboard configuration for PostHog",
+  "type": "object",
+  "required": ["name", "insights"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Dashboard name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Dashboard description"
+    },
+    "domain_filter": {
+      "type": "string",
+      "description": "Domain to filter events (e.g., blog.sylph.ai)"
+    },
+    "dashboard_id": {
+      "type": "integer",
+      "description": "PostHog dashboard ID (set after creation)"
+    },
+    "insights": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["pageviews_total", "unique_users", "traffic_trend", "top_pages", "custom"]
+          },
+          "display": {
+            "type": "string",
+            "enum": ["BoldNumber", "ActionsLineGraph", "ActionsTable", "ActionsBar"],
+            "default": "BoldNumber"
+          },
+          "event": {
+            "type": "string",
+            "default": "$pageview"
+          },
+          "math": {
+            "type": "string",
+            "enum": ["total", "dau", "weekly_active", "monthly_active"],
+            "default": "total"
+          },
+          "date_range": {
+            "type": "string",
+            "default": "-30d"
+          },
+          "breakdown": {
+            "type": "string",
+            "description": "Property to breakdown by (e.g., $current_url)"
+          },
+          "insight_id": {
+            "type": "integer",
+            "description": "PostHog insight ID (set after creation)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/posthog-analytics/examples/app_dashboard.json
+++ b/skills/posthog-analytics/examples/app_dashboard.json
@@ -1,0 +1,48 @@
+{
+  "name": "App Product Metrics",
+  "description": "Track user activation, engagement, and product usage for app.sylph.ai",
+  "domain_filter": "app.sylph.ai",
+  "dashboard_id": 1166740,
+  "insights": [
+    {
+      "name": "App Unique Users (Total)",
+      "type": "unique_users",
+      "display": "BoldNumber",
+      "date_range": "-30d"
+    },
+    {
+      "name": "App Pageviews (Total)",
+      "type": "pageviews_total",
+      "display": "BoldNumber",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Daily Active Users",
+      "type": "traffic_trend",
+      "display": "ActionsLineGraph",
+      "math": "dau",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Top App Pages",
+      "type": "top_pages",
+      "display": "ActionsTable",
+      "breakdown": "$current_url",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Weekly Active Users",
+      "type": "unique_users",
+      "display": "BoldNumber",
+      "math": "weekly_active",
+      "date_range": "-30d"
+    },
+    {
+      "name": "App Session Count",
+      "type": "pageviews_total",
+      "display": "ActionsLineGraph",
+      "event": "$pageview",
+      "date_range": "-7d"
+    }
+  ]
+}

--- a/skills/posthog-analytics/examples/blog_dashboard.json
+++ b/skills/posthog-analytics/examples/blog_dashboard.json
@@ -1,0 +1,33 @@
+{
+  "name": "Blog Analytics",
+  "description": "Track blog performance, reader engagement, and top content",
+  "domain_filter": "blog.sylph.ai",
+  "dashboard_id": null,
+  "insights": [
+    {
+      "name": "Blog Pageviews (Total)",
+      "type": "pageviews_total",
+      "display": "BoldNumber",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Unique Blog Readers",
+      "type": "unique_users",
+      "display": "BoldNumber",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Top Blog Posts",
+      "type": "top_pages",
+      "display": "ActionsTable",
+      "breakdown": "$current_url",
+      "date_range": "-30d"
+    },
+    {
+      "name": "Blog Traffic Trend",
+      "type": "traffic_trend",
+      "display": "ActionsLineGraph",
+      "date_range": "-30d"
+    }
+  ]
+}

--- a/skills/posthog-analytics/scripts/posthog_sync.sh
+++ b/skills/posthog-analytics/scripts/posthog_sync.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# PostHog Dashboard Sync Script
+# Usage: ./posthog_sync.sh <command> <config_file> [dashboard_id]
+
+set -e
+
+API_KEY="${POSTHOG_PERSONAL_API_KEY}"
+BASE_URL="${POSTHOG_HOST:-https://us.i.posthog.com}/api/projects/@current"
+
+if [ -z "$API_KEY" ]; then
+    echo "Error: POSTHOG_PERSONAL_API_KEY not set"
+    exit 1
+fi
+
+# Build insight query from type
+build_query() {
+    local type=$1
+    local domain=$2
+    local display=${3:-BoldNumber}
+    local math=${4:-total}
+    local event=${5:-\$pageview}
+    local date_range=${6:--30d}
+    local breakdown=$7
+    
+    local properties='{
+        "type": "AND",
+        "values": [{
+            "type": "AND", 
+            "values": [{
+                "key": "$current_url",
+                "value": "'"$domain"'",
+                "operator": "icontains",
+                "type": "event"
+            }]
+        }]
+    }'
+    
+    local breakdown_filter=""
+    if [ -n "$breakdown" ]; then
+        breakdown_filter=',"breakdownFilter": {"breakdown": "'"$breakdown"'", "breakdown_type": "event"}'
+    fi
+    
+    local interval=""
+    if [ "$display" = "ActionsLineGraph" ]; then
+        interval=',"interval": "day"'
+    fi
+    
+    echo '{
+        "kind": "InsightVizNode",
+        "source": {
+            "kind": "TrendsQuery",
+            "series": [{"kind": "EventsNode", "math": "'"$math"'", "event": "'"$event"'"}],
+            "properties": '"$properties"',
+            "dateRange": {"date_from": "'"$date_range"'"},
+            "trendsFilter": {"display": "'"$display"'"}'"$breakdown_filter$interval"'
+        }
+    }'
+}
+
+create_dashboard() {
+    local config_file=$1
+    local name=$(jq -r '.name' "$config_file")
+    local description=$(jq -r '.description // ""' "$config_file")
+    local domain=$(jq -r '.domain_filter // ""' "$config_file")
+    
+    echo "Creating dashboard: $name"
+    
+    # Create dashboard
+    local dashboard=$(curl -s -X POST "$BASE_URL/dashboards/" \
+        -H "Authorization: Bearer $API_KEY" \
+        -H "Content-Type: application/json" \
+        -d '{"name": "'"$name"'", "description": "'"$description"'"}')
+    
+    local dashboard_id=$(echo "$dashboard" | jq -r '.id')
+    echo "Dashboard created: ID $dashboard_id"
+    
+    # Create insights
+    local insights=$(jq -c '.insights[]' "$config_file")
+    while IFS= read -r insight; do
+        local insight_name=$(echo "$insight" | jq -r '.name')
+        local insight_type=$(echo "$insight" | jq -r '.type')
+        local display=$(echo "$insight" | jq -r '.display // "BoldNumber"')
+        local math=$(echo "$insight" | jq -r '.math // "total"')
+        local event=$(echo "$insight" | jq -r '.event // "$pageview"')
+        local date_range=$(echo "$insight" | jq -r '.date_range // "-30d"')
+        local breakdown=$(echo "$insight" | jq -r '.breakdown // ""')
+        
+        # Map type to display/math defaults
+        case $insight_type in
+            pageviews_total) display="BoldNumber"; math="total" ;;
+            unique_users) display="BoldNumber"; math="dau" ;;
+            traffic_trend) display="ActionsLineGraph"; math="total" ;;
+            top_pages) display="ActionsTable"; breakdown="\$current_url" ;;
+        esac
+        
+        local query=$(build_query "$insight_type" "$domain" "$display" "$math" "$event" "$date_range" "$breakdown")
+        
+        echo "Creating insight: $insight_name"
+        curl -s -X POST "$BASE_URL/insights/" \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{
+                "name": "'"$insight_name"'",
+                "dashboards": ['"$dashboard_id"'],
+                "query": '"$query"'
+            }' | jq '{id, name}'
+    done <<< "$insights"
+    
+    # Update config with dashboard_id
+    jq '.dashboard_id = '"$dashboard_id" "$config_file" > "${config_file}.tmp" && mv "${config_file}.tmp" "$config_file"
+    
+    echo ""
+    echo "Dashboard URL: https://us.i.posthog.com/dashboard/$dashboard_id"
+}
+
+export_dashboard() {
+    local dashboard_id=$1
+    
+    # Get dashboard with tiles
+    local dashboard=$(curl -s -H "Authorization: Bearer $API_KEY" "$BASE_URL/dashboards/$dashboard_id/")
+    local name=$(echo "$dashboard" | jq -r '.name')
+    local description=$(echo "$dashboard" | jq -r '.description // ""')
+    
+    # Extract insights from tiles (tiles contain insight objects)
+    local insights=$(echo "$dashboard" | jq -c '[.tiles[]? | select(.insight != null) | {name: .insight.name, insight_id: .insight.id, type: "custom"}]')
+    
+    # Build output JSON
+    echo "$dashboard" | jq '{
+        name: .name,
+        description: (.description // ""),
+        dashboard_id: .id,
+        domain_filter: "",
+        insights: [.tiles[]? | select(.insight != null) | {
+            name: .insight.name,
+            insight_id: .insight.id,
+            type: "custom"
+        }]
+    }'
+}
+
+sync_dashboard() {
+    local config_file=$1
+    local dashboard_id=$(jq -r '.dashboard_id' "$config_file")
+    local domain=$(jq -r '.domain_filter // ""' "$config_file")
+    
+    if [ "$dashboard_id" = "null" ] || [ -z "$dashboard_id" ]; then
+        echo "Error: No dashboard_id in config. Run 'create' first or add dashboard_id manually."
+        exit 1
+    fi
+    
+    echo "Syncing to dashboard: $dashboard_id"
+    
+    # Get existing insights on dashboard
+    local existing=$(curl -s -H "Authorization: Bearer $API_KEY" "$BASE_URL/dashboards/$dashboard_id/" | \
+        jq -r '[.tiles[]? | select(.insight != null) | .insight.name] | @json')
+    
+    echo "Existing insights: $existing"
+    
+    # Process each insight in config
+    local insights=$(jq -c '.insights[]' "$config_file")
+    while IFS= read -r insight; do
+        local insight_name=$(echo "$insight" | jq -r '.name')
+        local insight_id=$(echo "$insight" | jq -r '.insight_id // empty')
+        local insight_type=$(echo "$insight" | jq -r '.type')
+        local display=$(echo "$insight" | jq -r '.display // "BoldNumber"')
+        local math=$(echo "$insight" | jq -r '.math // "total"')
+        local event=$(echo "$insight" | jq -r '.event // "$pageview"')
+        local date_range=$(echo "$insight" | jq -r '.date_range // "-30d"')
+        local breakdown=$(echo "$insight" | jq -r '.breakdown // ""')
+        
+        # Map type to display/math defaults
+        case $insight_type in
+            pageviews_total) display="BoldNumber"; math="total" ;;
+            unique_users) display="BoldNumber"; math="dau" ;;
+            traffic_trend) display="ActionsLineGraph"; math="total" ;;
+            top_pages) display="ActionsTable"; breakdown="\$current_url" ;;
+        esac
+        
+        local query=$(build_query "$insight_type" "$domain" "$display" "$math" "$event" "$date_range" "$breakdown")
+        
+        # Check if insight exists (by name in existing list)
+        if echo "$existing" | jq -e 'index("'"$insight_name"'")' > /dev/null 2>&1; then
+            echo "Insight exists, skipping: $insight_name"
+        else
+            echo "Creating new insight: $insight_name"
+            local result=$(curl -s -X POST "$BASE_URL/insights/" \
+                -H "Authorization: Bearer $API_KEY" \
+                -H "Content-Type: application/json" \
+                -d '{
+                    "name": "'"$insight_name"'",
+                    "dashboards": ['"$dashboard_id"'],
+                    "query": '"$query"'
+                }')
+            echo "$result" | jq '{id, name}'
+        fi
+    done <<< "$insights"
+    
+    echo ""
+    echo "Sync complete: https://us.i.posthog.com/dashboard/$dashboard_id"
+}
+
+# Main
+case "${1:-help}" in
+    create)
+        [ -z "$2" ] && echo "Usage: $0 create <config.json>" && exit 1
+        create_dashboard "$2"
+        ;;
+    sync)
+        [ -z "$2" ] && echo "Usage: $0 sync <config.json>" && exit 1
+        sync_dashboard "$2"
+        ;;
+    export)
+        [ -z "$2" ] && echo "Usage: $0 export <dashboard_id>" && exit 1
+        export_dashboard "$2"
+        ;;
+    help|*)
+        echo "PostHog Dashboard Sync"
+        echo ""
+        echo "Usage:"
+        echo "  $0 create <config.json>     Create new dashboard from config"
+        echo "  $0 sync <config.json>       Sync config to existing dashboard (adds new insights)"
+        echo "  $0 export <dashboard_id>    Export dashboard to config"
+        echo ""
+        echo "Environment:"
+        echo "  POSTHOG_PERSONAL_API_KEY    Required - API key (phx_...)"
+        echo "  POSTHOG_HOST                Optional - API host (default: us.i.posthog.com)"
+        ;;
+esac


### PR DESCRIPTION
## Summary

Add reusable skill for PostHog dashboard automation. Great for startup founders who want to automate everything - version-control your analytics dashboards and deploy them via CI/CD.

## Changes

- `scripts/posthog_sync.sh` - Create/sync/export dashboard operations
- `dashboard_schema.json` - JSON schema for config validation
- `examples/blog_dashboard.json` - Blog analytics config
- `examples/app_dashboard.json` - App product metrics config
- `SKILL.md` - Documentation with API references

## Usage

```bash
# Create new dashboard from config
./scripts/posthog_sync.sh create examples/blog_dashboard.json

# Sync changes (add new insights)
./scripts/posthog_sync.sh sync examples/app_dashboard.json

# Export existing dashboard
./scripts/posthog_sync.sh export 1126158 > my_dashboard.json
```

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/AdalFlow)