### PR TITLE
fix: add YAML frontmatter to posthog-analytics skill

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -53,11 +53,13 @@ Ask for:
 mkdir -p ~/.adal/skills/<skill-name>
 ```
 
-Create `SKILL.md`:
+Create `SKILL.md` with **required YAML frontmatter**:
 ```markdown
 ---
 name: <skill-name>
 description: <Brief description>
+author: <your-name or org>
+version: 1.0.0
 ---
 
 # <Skill Title>
@@ -68,6 +70,8 @@ description: <Brief description>
 ## Instructions
 <Step-by-step guidance for the agent>
 ```
+
+> **⚠️ REQUIRED**: The `---` YAML frontmatter block is mandatory. Skills without it will fail to load. At minimum, include `name` and `description`.
 
 ### For Project Skills (`.adal/skills/`)
 

--- a/skills/posthog-analytics/SKILL.md
+++ b/skills/posthog-analytics/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: posthog-analytics
+description: Automate PostHog dashboard creation, sync, and export via API
+author: SylphAI-Inc
+version: 1.0.0
+---
+
 # PostHog Analytics Skill
 
 Automate PostHog dashboard creation, sync, and export via API.


### PR DESCRIPTION
## Summary

Add missing YAML frontmatter to posthog-analytics SKILL.md so it can be properly loaded by the skill loader.

## Problem

The skill loader validates YAML frontmatter in SKILL.md files. Without it, the skill was not being discovered via `/skills` command.

## Fix

Added standard frontmatter:
```yaml
---
name: posthog-analytics
description: Automate PostHog dashboard creation, sync, and export via API
author: SylphAI-Inc
version: 1.0.0
---
```

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/AdalFlow)