### PR TITLE
docs(create-skill): document both skills field formats

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -121,7 +121,9 @@ Same `SKILL.md` format. Remember to commit to git for team sharing.
    - `owner`: Object with `name` and `email` (required by Claude Code)
    - `metadata`: Wrapper for `description` and `version`
    - `plugins[].source`: Path to skills root (use `"./"` for repo root)
-   - `plugins[].skills`: Array of relative paths to skill directories
+   - `plugins[].skills`: **Two formats supported:**
+     - **Array** (explicit): `["./skills/xlsx", "./skills/docx"]` - list specific skill directories
+     - **String** (scan): `"skills"` or `"./"` - recursively scan for SKILL.md files
 
 3. **Installation commands:**
    ```bash


### PR DESCRIPTION
## Summary

Updates the create-skill SKILL.md to document both supported formats for the `skills` field in marketplace.json.

## Changes

- Clarifies that `plugins[].skills` supports two formats:
  - **Array** (explicit): `[\"./skills/xlsx\", \"./skills/docx\"]` - list specific skill directories
  - **String** (scan): `\"skills\"` or `\"./\"` - recursively scan for SKILL.md files

This helps plugin authors understand they have a choice when structuring their marketplace.

---
🌸 Generated with [AdaL](https://github.com/adal-cli/)