### PR TITLE
feat: add codegraph skill — turn any codebase into an explorable interactive graph

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,8 @@
         "./skills/create-skill",
         "./skills/posthog-analytics",
         "./skills/clone-anywebsite",
-        "./skills/glowmotion"
+        "./skills/glowmotion",
+        "./skills/codegraph"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ After installation, see all your available skills:
 | [posthog-analytics](./skills/posthog-analytics/SKILL.md) | Automate PostHog dashboard creation, sync, and export via API |
 | [clone-anywebsite](./skills/clone-anywebsite/SKILL.md) | Clone any website's landing page with pixel-perfect fidelity — visual-first workflow with sniper CSS extraction, animation detection, and mandatory Builder+Evaluator pattern |
 | [glowmotion](./skills/glowmotion/SKILL.md) | Create premium animated technical diagrams (flowcharts, architecture diagrams, Mermaid conversions) as single self-contained HTML+SVG files with glowing comet-dot flows, pulsing highlights, and a built-in light/dark theme toggle |
+| [codegraph](./skills/codegraph/SKILL.md) | Turn any codebase into an explorable interactive graph — deterministic structural scan (imports, symbols, PageRank importance, architectural layers, dependency cycles, entry points) plus AI summaries and guided tours, delivered as one self-contained HTML file |
 
 ### SWE CLI Skills (`swe-cli-skills` plugin)
 
@@ -91,6 +92,9 @@ See the [create-skill](./skills/create-skill/SKILL.md) guide for instructions on
 └── skills/                    # All skills organized by name
     ├── clone-anywebsite/
     │   └── SKILL.md
+    ├── codegraph/              # Interactive codebase graph generator
+    │   ├── SKILL.md
+    │   └── scripts/
     ├── create-skill/
     │   └── SKILL.md
     ├── glowmotion/             # Animated HTML+SVG diagram generator

--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: codegraph
+description: Turn any codebase into an explorable interactive graph so a developer can understand it fast. Deterministic scan (files, imports, symbols, call edges, PageRank importance, architectural layers, dependency cycles, entry points) plus optional AI enrichment (plain-English summaries and guided tours), delivered as ONE self-contained HTML file. Use when asked to explain, map, visualize, diagram, onboard onto, or understand a repository or its architecture.
+author: SylphAI-Inc
+version: 1.0.0
+---
+
+# codegraph
+
+Turn a codebase into a map a human can actually read.
+
+**The goal is not a graph that shows off how complex the code is — it is a graph that quietly teaches someone how the pieces fit together.**
+
+## When to Use
+
+Trigger on requests like:
+- "help me understand this codebase" / "I just joined this project"
+- "map / visualize / diagram this repo or its architecture"
+- "what are the entry points?" / "how does data flow through this?"
+- "generate an onboarding guide" / "where do I start reading?"
+- "show me the dependency graph" / "find circular dependencies"
+- "which files are most important here?"
+
+Do **not** use this for a single-file explanation — just read the file.
+
+## Core Design (read this before running anything)
+
+Three stages. Two are deterministic; only the middle one uses your intelligence.
+
+```
+1. scan.py    codebase  ->  graph.json + digest.md     deterministic, no LLM, no network
+2. YOU        digest.md ->  enrich.json                 summaries, layer fixes, tours
+3. render.py  both      ->  codegraph.html              one portable self-contained file
+              (overview.py collapses the graph into the overview diagram en route)
+```
+
+Why this split matters — **do not violate it**:
+
+| Stage | Owner | Guarantee |
+|---|---|---|
+| Structure (files, imports, calls, metrics, cycles) | `scan.py` | Reproducible. Same commit always yields the same edges. |
+| Meaning (what a file is *for*, tours) | You | Only a model can write this. |
+| Delivery (layout, validation, HTML) | `render.py` | Validated before write; a broken artifact never replaces a good one. |
+
+**Never hand-write `graph.json`.** It is machine output. You only ever write `enrich.json`.
+**Never invent files, symbols, or relationships.** Every id you emit must already exist in the digest.
+
+## Instructions
+
+### Step 1 — Scan (always start here)
+
+```bash
+python3 <skill>/scripts/scan.py <repo> -o <repo>/.codegraph
+```
+
+Nothing to install: Python 3.8+ stdlib only. ~2s for 230k LOC.
+
+Useful flags:
+- `--max-files N` (default 4000) — raise it if output warns about truncation
+- `--symbols-for N` (default 250) — extract function/class nodes for the N most important files
+- `--no-calls` — skip heuristic cross-file call edges (faster, fewer false positives)
+
+Then **read `digest.md`, not `graph.json`.** The digest is a compact briefing (entry points, directory map, ranked-importance table, cycles, dependencies, layer counts). `graph.json` can be megabytes and will flood your context for no benefit.
+
+### Step 2 — Enrich (this is your real work)
+
+Write `<repo>/.codegraph/enrich.json`:
+
+```json
+{
+  "project": { "description": "1-3 sentences: what this codebase IS and does." },
+  "nodes": {
+    "file:src/server.ts": {
+      "summary": "HTTP entry point. Wires middleware, mounts routers, starts the listener.",
+      "layer": "entry",
+      "tags": ["bootstrap", "http"]
+    }
+  },
+  "layers": { "service": "Domain logic; no HTTP or SQL touches this layer." },
+  "tours": [
+    {
+      "title": "Request lifecycle",
+      "description": "Follow one HTTP request end to end.",
+      "steps": [
+        { "nodeId": "file:src/server.ts", "note": "Request arrives; middleware chain runs here." },
+        { "nodeId": "file:src/routes/user.ts", "note": "Routing picks a handler." }
+      ]
+    }
+  ]
+}
+```
+
+Rules:
+1. **Node ids must come from the digest verbatim** (`file:...`, `mod:...`, `sym:...`, `ext:...`). Unknown ids are dropped with a warning — silent quality loss.
+2. **Summarize the top ~30-60 ranked files first.** Full coverage of a large repo is rarely worth the tokens; importance ordering already tells you what matters.
+3. Write **what it is + why it exists**, not a restatement of the filename. Bad: "Utils file with utilities." Good: "Retry/backoff helpers shared by every outbound API client."
+4. **Fix wrong layers.** `scan.py` guesses from paths and says so. If `core/` is really data access, override it.
+5. **At least one tour, 3-6 steps.** Tours are the single highest-value output for onboarding — they encode reading *order*, which a graph alone cannot.
+6. Read actual source before summarizing important files. Do not infer from names alone.
+
+Scale guidance: read the top files in batches, and prefer breadth (many short, correct summaries) over depth (a few essays).
+
+### Step 3 — Render and verify
+
+```bash
+python3 <skill>/scripts/render.py --in <repo>/.codegraph --open
+```
+
+- Validates first; on failure it prints exact reasons and writes nothing.
+- `--validate-only` to check without writing; `--strict` to fail on warnings.
+- Output: `<repo>/.codegraph/codegraph.html` — one file, no CDN, works offline, safe to commit or send.
+
+Always report to the user: node/edge counts, how many summaries and tours landed, and the artifact path.
+
+## What the artifact gives the reader
+
+**Three linked views in one file**, cycled with `Tab`:
+
+1. **overview** — architecture diagram (module boxes on layer bands, flowing
+   connectors, a comet on the primary dependency path). Answers *"what are the parts?"*
+2. **star map** — the same modules as an **orbitable** galaxy field, brightness =
+   importance (Physics-atlas idiom: hot cores, double halos, diffraction spikes).
+   Answers *"where is the weight of this system?"*
+   **Drag to orbit · scroll to dolly · shift-drag to pan · `0` to reset**, with damped
+   inertia and a slow idle auto-rotate — the same interaction contract as the atlas'
+   `OrbitControls`, implemented as a projected 2.5D disc in Canvas so the artifact
+   stays one dependency-free file (no three.js, no WebGL). Touch: one finger orbits,
+   two pinch-zoom. Modules carry real `z` depth, so tilting reveals structure and
+   distant galaxies fade.
+3. **explore** — an **expandable tree**, opened one level at a time. It starts at the
+   project root showing only the top folders, and each click reveals the next level:
+   folders -> files -> symbols. A `+N` badge on every collapsed node says how much is
+   inside, so nothing is hidden silently. The rail's **Start here** list jumps straight
+   to a real entry point. `H` toggles back to the flat all-at-once graph.
+
+Clicking a module box or a galaxy drills into explore, focused on that module's files.
+
+### Every node says something (no LLM required)
+
+`scan.py` reads the codebase's **own docstrings and file-header comments** — module
+docstrings, JSDoc blocks, Go/Rust line comments — and uses them as node summaries.
+Boilerplate (shebangs, licence headers, `coding:` lines) is filtered, and text is cut
+at `Args:`/`Returns:` so the summary stays one sentence.
+
+Measured on a real 109k-LOC repo: **87% of files described with zero model calls.**
+The agent's `enrich.json` overrides these where it can say something better, and the
+inspector labels which is which — an extracted summary is marked *from the file's
+docstring*, so provenance is never ambiguous. Nodes also list the symbols they define.
+
+This matters because a graph of unlabelled dots teaches nothing: before this, 100% of
+nodes showed only LOC and degree.
+
+The overview is *derived*, never authored: tiers, boxes, link weights and the journey
+all come from the deterministic scan, so the diagram cannot drift from the real code.
+Modules holding only config/docs are omitted (scaffolding is not architecture), and
+links are capped so a dense graph does not become a hairball.
+
+| Capability | Why it helps understanding |
+|---|---|
+| **Overview diagram** | The 5-second read: what this system is made of, and how it flows |
+| **Click a module → explore** | Overview answers "where?", explore answers "how?" |
+| 3 detail levels (Folders / Files / Symbols) | Progressive disclosure — start coarse, drill only where needed |
+| Layer bands (entry → api → service → data → util) | Shows architecture, not just a hairball |
+| Click any node | Summary, metrics, and **navigable** dependency lists both directions |
+| Search (`/`) | Find by name, path, summary text, or tag |
+| Focus dimming | Isolates one node's actual neighborhood |
+| `entries` toggle | "Where do I start reading?" answered instantly |
+| `cycles` toggle | Circular dependencies = refactor targets |
+| Guided tours (`P`, `[`, `]`) | Teaches reading order — the thing new devs lack most |
+| `calls` / `deps` toggles | Cross-file call edges; external dependency surface |
+| Theme toggle (`T`), fit (`0`) | Presentable in a README, PR, or onboarding doc |
+| **Flowing comet packets** | Dependency *direction* becomes visible motion, not a static arrow |
+| **Breathing halos** | Entry points, tour steps, and the selection pulse to draw the eye |
+| **Motion toggle** (`space`, ⏸) | Pause for screenshots; auto-off under `prefers-reduced-motion` |
+| `Tab` | Flip between overview and explore |
+| **`simplify`** (`F`) | Folds edges of hub files — the single biggest declutter (~−48%) |
+| **`focus`** (`N`) | Shows only the selection and its top neighbours (~−87%) |
+
+### Asking questions mid-explore
+
+The artifact is offline and carries no API key, so it does not pretend to host a chat.
+Instead every node has an **`ask ▸`** button that copies a complete prompt — path,
+summary, LOC/fan-in/fan-out, the symbols it defines, and both edge directions — ready
+to paste into any LLM. That is the context a model would otherwise have to guess at.
+
+Deliberately NOT done: embedding an API key in the HTML. The file gets committed and
+shared, so a key in it is a leak waiting to happen.
+
+### Keeping explore readable
+
+Dense repos produce a hairball, so the explore view **starts simplified** and lets the
+reader add detail back:
+
+- **Tests hidden by default** — often half a repo's files, but not its architecture.
+- **Hub folding on by default.** A handful of files carry most of the clutter (in one
+  109k-LOC repo, 10 files owned 23% of all edge endpoints). Their edges collapse to a
+  `⋯n` badge; click it to reveal them. Nothing disappears silently.
+- **`calls` edges off by default** — they typically outnumber imports ~5:1.
+- **Distance LOD** — zoomed far out the lines fade and the layer bands carry the
+  structure (borrowed from Physics-atlas's `uReveal`).
+- **Neighbourhood focus** (`N`) — one node's direct relations only, capped so an
+  extreme hub cannot re-create the hairball.
+
+Measured on a 109k-LOC repo: **628 → 172 edges (−73%)** at defaults, **−87%** in focus mode.
+
+**Why not 3D?** It looks like the answer but is not: the clutter is edge *count*, not
+missing dimension, and 3D adds occlusion, rotation disorientation, and a ~600KB
+three.js dependency that breaks the single-file offline contract. LOD plus folding
+solves the actual problem.
+
+### Animation
+
+The artifact is alive by default, in the glowmotion/deep-field idiom:
+
+- **Comet packets** travel source → target along each edge with an exponential
+  fading trail, so import direction reads at a glance. Colour encodes kind
+  (blue = imports, violet = calls, gold = the active tour path).
+- **Focus redirects traffic**: selecting a node concentrates packets on its
+  neighbourhood and fades the rest to 6%.
+- **Breathing halos** ring entry points, tour steps, and the selection.
+- **Parallax starfield** drifts behind the graph as you pan (dark theme only;
+  the light theme stays print-clean).
+
+Performance is decoupled from graph size: the static scene is painted once on a
+base canvas and motion lives on a separate overlay, with packets capped at 190.
+Measured **60fps on a 2,660-node graph**. Motion pauses on `space` / ⏸ and is
+off automatically when the viewer prefers reduced motion.
+
+## Graph Vocabulary
+
+**Node ids are typed prefixes** (stable, so deep links and enrichment keep working):
+
+| Prefix | Meaning |
+|---|---|
+| `mod:<dir>` | Folder / module |
+| `file:<path>` | A file |
+| `sym:<path>#<name>:<line>` | Function / class / type |
+| `ext:<name>` | External dependency |
+
+**Edges**: `contains` (hierarchy), `imports` (resolved, reliable), `calls` (heuristic — name-based, unique-match only), `depends_on` (external), `inherits`.
+
+**Layers**: `entry`, `ui`, `api`, `service`, `data`, `util`, `config`, `infra`, `test`, `docs`, `other`.
+
+**Importance** = 0.55·PageRank(imports) + 0.25·fan-in + 0.20·size. It answers "what should I read first?"
+
+## Languages
+
+Python, JS/TS (+JSX/TSX), Vue, Svelte, Go, Rust, Java, Kotlin, Scala, Ruby, PHP, C#, C/C++, Objective-C, Swift, shell, SQL, Terraform, GraphQL, Protobuf — plus config/docs/Docker as context nodes.
+
+Import resolution is real (relative paths, package roots, `@/` aliases, Go modules, Rust `crate::`/`mod`, JVM packages). Extraction is regex-based, not a full type-checking AST: excellent for imports and definitions, approximate for call edges. **Tell the user this when they ask about call accuracy** — never present inferred calls as verified fact.
+
+## Honest Limits
+
+- `calls` edges are heuristic (unique unambiguous names only; common names like `get`/`run` are deliberately skipped). Imports are trustworthy; calls are a hint.
+- Dynamic imports, DI containers, reflection, and runtime registration are invisible to static scanning.
+- Generated code, minified bundles, and lockfiles are excluded on purpose.
+- Layers are path heuristics until you override them. Say so rather than overclaiming.
+
+## Refresh
+
+Re-run `scan.py` then `render.py`. `enrich.json` is separate from `graph.json`, so **existing summaries survive a re-scan** — only ids that no longer exist get dropped. Commit `.codegraph/` to let teammates open the graph with zero setup and no API key.

--- a/skills/codegraph/scripts/overview.py
+++ b/skills/codegraph/scripts/overview.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""
+codegraph overview — collapse a file graph into a readable architecture diagram.
+
+This is the glowmotion half of the artifact: instead of thousands of file dots,
+it produces 8-14 module boxes on architectural tiers, with orthogonal routes and
+a primary journey — the kind of picture a human can absorb in five seconds.
+
+The difference from glowmotion: nothing here is hand-authored. Tiers, boxes,
+edge weights and the journey are all DERIVED from the deterministic scan, so the
+overview cannot drift from the real code.
+
+Design contract:
+  * stdlib only, no network, deterministic (same graph -> identical geometry).
+  * Pure geometry + semantics; the HTML/SVG is emitted by the viewer.
+  * Never invents a module or an edge that the scan did not find.
+
+Used by render.py; also runnable standalone for inspection:
+    python3 overview.py .codegraph/graph.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections import Counter, defaultdict
+
+# Architectural reading order, top to bottom. Mirrors scan.py's LAYER_ORDER but
+# drops the layers that add noise to a high-level picture (tests/docs).
+TIER_ORDER = ["entry", "ui", "api", "service", "data", "util", "config", "infra"]
+TIER_LABELS = {
+    "entry": "Entry", "ui": "UI", "api": "API", "service": "Logic",
+    "data": "Data", "util": "Shared", "config": "Config", "infra": "Infra",
+    "test": "Tests", "docs": "Docs", "other": "Other",
+}
+OMIT_LAYERS = {"test", "docs"}
+
+# Box geometry, in the same user units the viewer's SVG viewBox uses.
+BOX_W, BOX_H = 168, 62
+GAP_X, GAP_Y = 40, 96
+PAD = 40          # leaves room for the band label drawn above each row
+
+
+def _short(path: str) -> str:
+    """A module label a human recognises: last one or two path segments."""
+    if path in (".", ""):
+        return "(root)"
+    parts = [p for p in path.split("/") if p]
+    if len(parts) <= 2:
+        return "/".join(parts)
+    return ".../" + "/".join(parts[-2:])
+
+
+def collapse(graph, max_boxes=14):
+    """Group file nodes into module boxes, keeping the most significant ones."""
+    nodes = graph.get("nodes") or []
+    by_id = {n["id"]: n for n in nodes}
+
+    files = [n for n in nodes
+             if n.get("type") in ("file", "config", "document") and n.get("filePath")]
+    if not files:
+        return [], [], {}
+
+    # Aggregate every file into its owning directory.
+    mods = {}
+    for n in files:
+        layer = n.get("layer") or "other"
+        mod = n.get("module") or ("mod:" + (os.path.dirname(n["filePath"]) or "."))
+        m = mods.get(mod)
+        if not m:
+            m = mods[mod] = {
+                "id": mod, "path": mod[4:] if mod.startswith("mod:") else mod,
+                "files": [], "loc": 0, "importance": 0.0,
+                "layers": Counter(), "langs": Counter(),
+                "entries": 0, "code": 0, "summary": "", "tags": [],
+            }
+        if n.get("type") == "file":        # real source, not config/doc
+            m["code"] += 1
+        m["files"].append(n["id"])
+        m["loc"] += n.get("loc") or 0
+        m["importance"] += n.get("importance") or 0.0
+        m["layers"][layer] += 1
+        if n.get("language"):
+            m["langs"][n["language"]] += 1
+        if n.get("isEntry"):
+            m["entries"] += 1
+
+    for m in mods.values():
+        m["layer"] = m["layers"].most_common(1)[0][0]
+        m["fileCount"] = len(m["files"])
+        m["label"] = _short(m["path"])
+        # Borrow the best summary among the module's files, preferring the
+        # most important one the agent actually described.
+        best, best_imp = "", -1.0
+        for fid in m["files"]:
+            f = by_id.get(fid) or {}
+            if f.get("summary") and (f.get("importance") or 0) > best_imp:
+                best, best_imp = f["summary"], f.get("importance") or 0
+        m["summary"] = best
+        tags = Counter()
+        for fid in m["files"]:
+            for t in (by_id.get(fid) or {}).get("tags") or []:
+                tags[t] += 1
+        m["tags"] = [t for t, _ in tags.most_common(3)]
+
+    # Rank and keep the modules worth showing; the rest are omitted (the explore
+    # view still has every file, so nothing is lost — only summarized away).
+    ranked = sorted(mods.values(),
+                    key=lambda m: (-(m["importance"] + m["entries"] * 0.5), -m["loc"], m["path"]))
+    candidates = [m for m in ranked if m["layer"] not in OMIT_LAYERS]
+
+    # Drop scaffolding-only modules: a directory holding nothing but config or
+    # docs (a lone package.json) is not architecture. Note this is about KIND,
+    # not size — a small module of real code (a package's public __init__) stays.
+    def worth_showing(m):
+        if m["entries"]:
+            return True
+        if not m["code"]:                 # no source files at all
+            return False
+        return m["importance"] > 0.02 or (m["fileCount"] >= 2 and m["loc"] >= 20)
+
+    filtered = [m for m in candidates if worth_showing(m)]
+    visible = (filtered or candidates)[:max_boxes]
+    if not visible:
+        visible = ranked[:max_boxes]
+    keep = {m["id"] for m in visible}
+
+    # Map every file to its visible module (or None when its module was dropped).
+    file_to_box = {}
+    for m in mods.values():
+        target = m["id"] if m["id"] in keep else None
+        for fid in m["files"]:
+            file_to_box[fid] = target
+
+    # Aggregate file-level imports into module-level edges.
+    weights = Counter()
+    for e in graph.get("edges") or []:
+        if e.get("type") not in ("imports", "calls"):
+            continue
+        a = file_to_box.get(e.get("source"))
+        b = file_to_box.get(e.get("target"))
+        # calls may originate from a symbol; resolve through its parent file.
+        if a is None:
+            sa = by_id.get(e.get("source")) or {}
+            a = file_to_box.get("file:" + sa.get("filePath", "")) if sa.get("filePath") else None
+        if b is None:
+            sb = by_id.get(e.get("target")) or {}
+            b = file_to_box.get("file:" + sb.get("filePath", "")) if sb.get("filePath") else None
+        if not a or not b or a == b:
+            continue
+        weights[(a, b)] += 1
+
+    # Cap the connector count. A dense module graph is near-complete, and drawing
+    # every link recreates the hairball the overview exists to avoid. Keep the
+    # heaviest links, but guarantee every box keeps its single strongest tie so
+    # nothing is left visually orphaned.
+    ranked_edges = sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))
+    budget = max(18, min(46, len(visible) * 3))
+    kept = dict(ranked_edges[:budget])
+    connected = {n for pair in kept for n in pair}
+    for (a, b), w in ranked_edges:
+        if len(kept) >= budget + len(visible):
+            break
+        if a not in connected or b not in connected:
+            kept[(a, b)] = w
+            connected.update((a, b))
+
+    edges = [{"from": a, "to": b, "weight": w} for (a, b), w in kept.items()]
+    return visible, edges, file_to_box
+
+
+def assign_tiers(boxes, edges):
+    """Place boxes on rows: architectural layer first, longest-path as tiebreak."""
+    present = [t for t in TIER_ORDER if any(b["layer"] == t for b in boxes)]
+    extra = sorted({b["layer"] for b in boxes} - set(present))
+    order = present + extra
+    row_of = {t: i for i, t in enumerate(order)}
+    for b in boxes:
+        b["tier"] = row_of.get(b["layer"], len(order))
+    return order
+
+
+MAX_COLS = 4          # wrap wide tiers so the diagram stays landscape
+
+
+def layout(boxes, edges, tier_order):
+    """Deterministic row packing + orthogonal routing. Returns (geometry, size)."""
+    grouped = defaultdict(list)
+    for b in boxes:
+        grouped[b["tier"]].append(b)
+
+    # A tier holding one box would waste a whole row, so adjacent single-box
+    # tiers share a row; wide tiers wrap at MAX_COLS. Reading order is kept.
+    rows, row_tiers = [], []
+    for tier in sorted(grouped):
+        members = sorted(grouped[tier], key=lambda b: (-b["importance"], b["path"]))
+        # Merge a lone box onto the previous row only if that row is also sparse;
+        # append (never prepend) so left-to-right still follows tier order.
+        if (len(members) == 1 and rows and len(rows[-1]) < MAX_COLS
+                and len(row_tiers[-1]) < 3 and len(rows[-1]) <= 2):
+            rows[-1].extend(members)
+            row_tiers[-1].append(tier)
+            continue
+        for i in range(0, len(members), MAX_COLS):
+            rows.append(members[i:i + MAX_COLS])
+            row_tiers.append([tier])
+
+    max_cols = max((len(r) for r in rows), default=1)
+    width = PAD * 2 + max_cols * BOX_W + (max_cols - 1) * GAP_X
+    height = PAD * 2 + len(rows) * BOX_H + max(0, len(rows) - 1) * GAP_Y
+
+    for ri, row in enumerate(rows):
+        # Within a merged row, keep tier order left-to-right so the eye still
+        # travels entry -> ui -> api rather than jumping by size.
+        row.sort(key=lambda b: (b["tier"], -b["importance"], b["path"]))
+        n = len(row)
+        span = n * BOX_W + (n - 1) * GAP_X
+        x0 = (width - span) / 2
+        y = PAD + ri * (BOX_H + GAP_Y)
+        for ci, b in enumerate(row):
+            b["x"] = round(x0 + ci * (BOX_W + GAP_X), 1)
+            b["y"] = round(y, 1)
+            b["w"], b["h"] = BOX_W, BOX_H
+            b["row"], b["col"] = ri, ci
+
+    pos = {b["id"]: b for b in boxes}
+    for e in edges:
+        a, b = pos.get(e["from"]), pos.get(e["to"])
+        if not a or not b:
+            e["d"] = ""
+            continue
+        e["d"] = route(a, b)
+        e["down"] = b["y"] > a["y"]
+    # Row labels come from whichever tiers landed on each row.
+    labels = [[t for t in ts] for ts in row_tiers]
+    return width, round(height), labels
+
+
+def route(a, b):
+    """Orthogonal path between two boxes, leaving each from the nearer face.
+
+    Downward edges exit the bottom and enter the top with a mid-way jog, which
+    keeps them clear of the boxes in between (the C2 rule glowmotion enforces).
+    Same-row and upward edges bow out to the side instead of cutting through.
+    """
+    ax, ay = a["x"] + a["w"] / 2, a["y"]
+    bx, by = b["x"] + b["w"] / 2, b["y"]
+
+    if by > ay:                                   # downward: bottom -> top
+        y1 = a["y"] + a["h"]
+        y2 = b["y"]
+        if abs(bx - ax) < 1:
+            return "M%.1f %.1f L%.1f %.1f" % (ax, y1, bx, y2)
+        mid = (y1 + y2) / 2
+        return "M%.1f %.1f L%.1f %.1f L%.1f %.1f L%.1f %.1f" % (
+            ax, y1, ax, mid, bx, mid, bx, y2)
+
+    if abs(by - ay) < 1:                          # same row: side to side
+        if bx > ax:
+            x1, x2 = a["x"] + a["w"], b["x"]
+        else:
+            x1, x2 = a["x"], b["x"] + b["w"]
+        y = ay + a["h"] / 2
+        return "M%.1f %.1f L%.1f %.1f" % (x1, y, x2, y)
+
+    # upward (feedback): leave the side, climb clear of the rows, re-enter bottom
+    out = a["x"] + a["w"] + 22 if bx >= ax else a["x"] - 22
+    y1 = ay + a["h"] / 2
+    y2 = b["y"] + b["h"]
+    return "M%.1f %.1f L%.1f %.1f L%.1f %.1f L%.1f %.1f" % (
+        (a["x"] + a["w"] if bx >= ax else a["x"]), y1, out, y1, out, y2, bx, y2)
+
+
+def primary_journey(boxes, edges, limit=6):
+    """The longest high-traffic downward path — the story the diagram tells.
+
+    Depth-first over downward edges only (so it always reads top-to-bottom),
+    preferring heavier edges. This is the animated route.
+    """
+    if not boxes:
+        return []
+    pos = {b["id"]: b for b in boxes}
+    out = defaultdict(list)
+    for e in edges:
+        a, b = pos.get(e["from"]), pos.get(e["to"])
+        if a and b and b["y"] > a["y"]:
+            out[e["from"]].append((e["weight"], e["to"]))
+    for k in out:
+        out[k].sort(reverse=True)
+
+    best = []
+
+    def walk(node, path, seen):
+        nonlocal best
+        if len(path) > len(best):
+            best = list(path)
+        if len(path) >= limit:
+            return
+        for _, nxt in out.get(node, [])[:3]:
+            if nxt in seen:
+                continue
+            seen.add(nxt)
+            path.append(nxt)
+            walk(nxt, path, seen)
+            path.pop()
+            seen.discard(nxt)
+
+    # Start from the topmost, most important boxes.
+    starts = sorted(boxes, key=lambda b: (b["row"], -b["importance"]))[:4]
+    for s in starts:
+        walk(s["id"], [s["id"]], {s["id"]})
+        if len(best) >= limit:
+            break
+
+    # A flat project (everything on one row) still deserves a journey: fall back
+    # to the heaviest same-row chain so the diagram is never motionless.
+    if len(best) < 2:
+        flat = sorted(edges, key=lambda e: -e["weight"])
+        if flat:
+            best = [flat[0]["from"], flat[0]["to"]]
+            nxt = {e["from"]: e["to"] for e in flat}
+            seen = set(best)
+            while len(best) < limit and best[-1] in nxt and nxt[best[-1]] not in seen:
+                best.append(nxt[best[-1]])
+                seen.add(best[-1])
+
+    hops = [[best[i], best[i + 1]] for i in range(len(best) - 1)]
+    return hops
+
+
+def starmap(graph, boxes, file_to_box):
+    """Galaxy layout:每个模块是一个星系，文件是星，重要度决定亮度与大小。
+
+    与 box 视图互补 —— box 讲"架构分层"，星图讲"质量分布"：
+    哪些模块是巨大的恒星形成区，哪些只是稀疏的尘埃。
+
+    Deterministic: 角度与半径全部由 id hash 与排名决定，无随机。
+    """
+    nodes = graph.get("nodes") or []
+    by_mod = defaultdict(list)
+    for n in nodes:
+        if n.get("type") not in ("file", "config", "document"):
+            continue
+        box = file_to_box.get(n["id"])
+        if box:
+            by_mod[box].append(n)
+
+    W = H = 1000.0
+    cx, cy = W / 2, H / 2
+    order = sorted(boxes, key=lambda b: -(b["importance"] + b["loc"] / 5000.0))
+
+    galaxies, stars = [], []
+    n_gal = max(1, len(order))
+    for gi, b in enumerate(order):
+        # 黄金角螺旋：星系彼此不重叠，且中心密、外围疏
+        t = (gi + 0.5) / n_gal
+        ang = gi * 2.39996                      # golden angle, rad
+        rad = (0.13 + 0.80 * math.sqrt(t)) * (W * 0.46)
+        gx, gy = cx + math.cos(ang) * rad, cy + math.sin(ang) * rad
+        # z gives the disc real thickness so tilting the camera reveals depth.
+        # Important modules sit near the galactic plane; peripheral ones drift out.
+        gz = (hash_f(b["id"] + "z") - 0.5) * 190 * (1.0 - 0.55 * (1.0 - t))
+        members = sorted(by_mod.get(b["id"], []),
+                         key=lambda n: -(n.get("importance") or 0))
+        # 星系半径随成员数增长，但收敛（sqrt）以免大模块吞掉画面
+        gr = 26 + min(78, math.sqrt(max(1, len(members))) * 15)
+        galaxies.append({
+            "id": b["id"], "label": b["label"], "layer": b["layer"],
+            "x": round(gx, 1), "y": round(gy, 1), "z": round(gz, 1),
+            "r": round(gr, 1),
+            "files": len(members), "loc": b["loc"],
+            "summary": b.get("summary", ""),
+        })
+        for si, n in enumerate(members[:60]):
+            st = (si + 0.5) / max(1, min(len(members), 60))
+            sang = si * 2.39996 + hash_f(n["id"]) * 6.283
+            srad = math.sqrt(st) * gr * 0.92
+            imp = n.get("importance") or 0
+            loc = n.get("loc") or 1
+            # Stars scatter around their galaxy's plane; brighter ones hug it,
+            # so tilting keeps the important stars readable instead of scattered.
+            sz = gz + (hash_f(n["id"] + "z") - 0.5) * gr * 0.85 * (1.25 - imp)
+            stars.append({
+                "id": n["id"], "name": n["name"], "mod": b["id"],
+                "x": round(gx + math.cos(sang) * srad, 1),
+                "y": round(gy + math.sin(sang) * srad, 1),
+                "z": round(sz, 1),
+                # 视星等。不做线性截断——那会让 top 文件全部饱和成 1.00，
+                # 失去区分度。用平方根压缩保留高端差异。
+                "mag": round(min(1.0, math.sqrt(
+                    min(1.0, imp * 1.1 + min(loc / 2600.0, 0.30)))), 3),
+                "layer": n.get("layer") or "other",
+                "loc": loc,
+            })
+
+    # 星系之间的"光丝"：模块级依赖，权重决定亮度
+    pos = {g["id"]: g for g in galaxies}
+    links = []
+    for e in _module_edges(graph, file_to_box):
+        a, b2 = pos.get(e["from"]), pos.get(e["to"])
+        if not a or not b2:
+            continue
+        links.append({"from": e["from"], "to": e["to"], "weight": e["weight"]})
+    links.sort(key=lambda l: -l["weight"])
+    return {"width": W, "height": H, "galaxies": galaxies,
+            "stars": stars, "links": links[:70]}
+
+
+def hash_f(s):
+    """Deterministic 0..1 from a string (same FNV-1a the viewer uses)."""
+    h = 2166136261
+    for ch in s:
+        h ^= ord(ch)
+        h = (h * 16777619) & 0xFFFFFFFF
+    return h / 4294967295.0
+
+
+def _module_edges(graph, file_to_box):
+    """Module-level import/call weights, shared by both overview layouts."""
+    by_id = {n["id"]: n for n in graph.get("nodes") or []}
+    w = Counter()
+    for e in graph.get("edges") or []:
+        if e.get("type") not in ("imports", "calls"):
+            continue
+        a = file_to_box.get(e.get("source"))
+        b = file_to_box.get(e.get("target"))
+        if a is None:
+            s = by_id.get(e.get("source")) or {}
+            a = file_to_box.get("file:" + s.get("filePath", "")) if s.get("filePath") else None
+        if b is None:
+            t = by_id.get(e.get("target")) or {}
+            b = file_to_box.get("file:" + t.get("filePath", "")) if t.get("filePath") else None
+        if a and b and a != b:
+            w[(a, b)] += 1
+    return [{"from": a, "to": b, "weight": c} for (a, b), c in w.items()]
+
+
+def build(graph, max_boxes=14):
+    """Return the overview payload the viewer renders as SVG."""
+    boxes, edges, file_to_box = collapse(graph, max_boxes)
+    if not boxes:
+        return None
+    tier_order = assign_tiers(boxes, edges)
+    width, height, row_labels = layout(boxes, edges, tier_order)
+    hops = primary_journey(boxes, edges)
+
+    # Keep only what the viewer needs; drop the file id lists (they can be large).
+    lean = []
+    for b in boxes:
+        lean.append({
+            "id": b["id"], "label": b["label"], "path": b["path"],
+            "layer": b["layer"], "tier": b["tier"], "row": b["row"],
+            "x": b["x"], "y": b["y"], "w": b["w"], "h": b["h"],
+            "loc": b["loc"], "fileCount": b["fileCount"],
+            "entries": b["entries"], "summary": b["summary"], "tags": b["tags"],
+            "lang": (b["langs"].most_common(1)[0][0] if b["langs"] else ""),
+        })
+    # One label per rendered row, joined when tiers were merged onto one row.
+    # row_labels holds tier *indices*; map them back to layer ids.
+    rows = []
+    for ri, tier_idxs in enumerate(row_labels):
+        names = [tier_order[i] if i < len(tier_order) else "other" for i in tier_idxs]
+        y = min((b["y"] for b in boxes if b["row"] == ri), default=0)
+        rows.append({
+            "row": ri, "y": y,
+            "label": " · ".join(TIER_LABELS.get(t, t.title()) for t in names),
+            "layer": names[0],
+        })
+    return {
+        "width": width, "height": height,
+        "rows": rows,
+        "boxes": lean,
+        "edges": [e for e in edges if e.get("d")],
+        "journey": hops,
+        # Second, complementary reading of the same data: mass and clustering
+        # instead of layering. Cheap to compute, so both ship in one artifact.
+        "starmap": starmap(graph, boxes, file_to_box),
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="overview.py",
+        description="Collapse graph.json into an architecture overview (codegraph)")
+    ap.add_argument("graph", help="path to graph.json")
+    ap.add_argument("--max-boxes", type=int, default=14)
+    args = ap.parse_args(argv)
+
+    with open(args.graph, "r", encoding="utf-8") as fh:
+        graph = json.load(fh)
+    ov = build(graph, args.max_boxes)
+    if not ov:
+        print("error: no file nodes to summarize", file=sys.stderr)
+        return 1
+    print(json.dumps(ov, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/codegraph/scripts/render.py
+++ b/skills/codegraph/scripts/render.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+codegraph render — graph.json (+ optional enrich.json) -> ONE self-contained HTML.
+
+Stage 3 of 3 in the codegraph pipeline:
+
+    scan.py   ->  graph.json + digest.md      (deterministic structure)
+    agent     ->  enrich.json                 (semantic summaries / layers / tours)
+    render.py ->  codegraph.html              (this file)
+
+Design contract:
+  * ZERO third-party dependencies (stdlib only) and ZERO CDN/network calls at view time.
+  * Validate BEFORE writing. A broken artifact never replaces a good one:
+    we render to a temp file in the same directory and atomically os.replace().
+  * The output is one portable file you can commit, email, or open offline.
+
+Usage:
+    python3 render.py [--in .codegraph] [--enrich .codegraph/enrich.json]
+                      [-o .codegraph/codegraph.html] [--title TEXT] [--open]
+    python3 render.py --validate-only --in .codegraph
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import webbrowser
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import overview  # noqa: E402  (sibling module, stdlib-only)
+
+# --------------------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------------------
+
+REQUIRED_TOP = ("version", "project", "nodes", "edges")
+
+
+def validate_graph(graph):
+    """Return (errors, warnings). Errors block delivery; warnings are informational."""
+    errors, warnings = [], []
+
+    if not isinstance(graph, dict):
+        return ["graph.json is not a JSON object"], []
+    for key in REQUIRED_TOP:
+        if key not in graph:
+            errors.append("missing required top-level key: %r" % key)
+    if errors:
+        return errors, warnings
+
+    nodes = graph.get("nodes") or []
+    edges = graph.get("edges") or []
+    if not isinstance(nodes, list) or not nodes:
+        errors.append("nodes must be a non-empty list")
+        return errors, warnings
+    if not isinstance(edges, list):
+        errors.append("edges must be a list")
+        return errors, warnings
+
+    ids = {}
+    for i, n in enumerate(nodes):
+        if not isinstance(n, dict):
+            errors.append("nodes[%d] is not an object" % i)
+            continue
+        nid = n.get("id")
+        if not nid or not isinstance(nid, str):
+            errors.append("nodes[%d] has no valid string id" % i)
+            continue
+        if nid in ids:
+            errors.append("duplicate node id: %r" % nid)
+        ids[nid] = True
+        if not n.get("name"):
+            warnings.append("node %r has no name" % nid)
+
+    dangling = 0
+    for e in edges:
+        if not isinstance(e, dict):
+            errors.append("an edge is not an object")
+            break
+        s, t = e.get("source"), e.get("target")
+        if s not in ids or t not in ids:
+            dangling += 1
+    if dangling:
+        errors.append("%d edge(s) reference unknown node ids" % dangling)
+
+    if not graph.get("layers"):
+        warnings.append("no layers present; layer filter will be empty")
+    return errors, warnings
+
+
+def validate_enrich(enrich, node_ids):
+    """Enrichment is advisory: unknown ids are dropped with a warning, never fatal."""
+    warnings = []
+    if not isinstance(enrich, dict):
+        return {}, ["enrich.json is not an object; ignored"]
+
+    clean = {"project": {}, "nodes": {}, "layers": {}, "tours": []}
+
+    proj = enrich.get("project")
+    if isinstance(proj, dict):
+        clean["project"] = {k: v for k, v in proj.items() if isinstance(v, str)}
+
+    nodes = enrich.get("nodes")
+    if isinstance(nodes, dict):
+        unknown = 0
+        for nid, payload in nodes.items():
+            if nid not in node_ids:
+                unknown += 1
+                continue
+            if isinstance(payload, str):
+                clean["nodes"][nid] = {"summary": payload}
+            elif isinstance(payload, dict):
+                clean["nodes"][nid] = payload
+        if unknown:
+            warnings.append("enrich.nodes: dropped %d entry(ies) with unknown node ids" % unknown)
+
+    layers = enrich.get("layers")
+    if isinstance(layers, dict):
+        clean["layers"] = {k: v for k, v in layers.items() if isinstance(v, str)}
+
+    tours = enrich.get("tours") or enrich.get("tour")
+    if isinstance(tours, list):
+        for t in tours:
+            if not isinstance(t, dict):
+                continue
+            steps = []
+            for st in (t.get("steps") or []):
+                if isinstance(st, str):
+                    nid, note = st, ""
+                elif isinstance(st, dict):
+                    nid, note = st.get("nodeId") or st.get("id"), st.get("note", "")
+                else:
+                    continue
+                if nid in node_ids:
+                    steps.append({"nodeId": nid, "note": note})
+            if steps:
+                clean["tours"].append({
+                    "title": t.get("title") or "Tour",
+                    "description": t.get("description", ""),
+                    "steps": steps,
+                })
+            elif t.get("title"):
+                warnings.append("tour %r dropped: no steps matched known node ids" % t["title"])
+    return clean, warnings
+
+
+def merge(graph, enrich):
+    """Fold enrichment into the graph. Structure always wins; semantics fill the gaps."""
+    if enrich.get("project", {}).get("description"):
+        graph["project"]["description"] = enrich["project"]["description"]
+
+    by_id = {n["id"]: n for n in graph["nodes"]}
+    enriched_count = 0
+    # A node with no agent summary still deserves words: fall back to the file's
+    # own docstring so the inspector is never just numbers.
+    doc_count = 0
+    for node in graph["nodes"]:
+        if not node.get("summary") and node.get("doc"):
+            node["summary"] = node["doc"]
+            node["summarySource"] = "docstring"
+            doc_count += 1
+    graph["docSummaries"] = doc_count
+    for nid, payload in enrich.get("nodes", {}).items():
+        node = by_id.get(nid)
+        if not node:
+            continue
+        if payload.get("summary"):
+            # The agent's words win over the extracted docstring.
+            node["summary"] = payload["summary"]
+            node["summarySource"] = "agent"
+            enriched_count += 1
+        if payload.get("layer"):
+            node["layer"] = payload["layer"]
+        tags = payload.get("tags")
+        if isinstance(tags, list):
+            node["tags"] = [str(t) for t in tags][:8]
+
+    for layer in graph.get("layers", []):
+        desc = enrich.get("layers", {}).get(layer["id"])
+        if desc:
+            layer["description"] = desc
+
+    if enrich.get("tours"):
+        graph["tour"] = enrich["tours"]
+    graph["enrichedNodes"] = enriched_count
+    return graph
+
+
+def slim(graph):
+    """Strip fields the viewer never reads, so the HTML stays small."""
+    keep_node = {
+        "id", "type", "name", "filePath", "module", "language", "layer", "loc",
+        "fanIn", "fanOut", "importance", "isEntry", "defCount", "routes",
+        "httpVerbs", "title", "summary", "tags", "lineRange", "kind",
+        "fileCount", "languages", "usedBy", "importCount", "doc", "symbols",
+        "summarySource", "parent", "depth", "ownFiles",
+    }
+    out = dict(graph)
+    out["nodes"] = [{k: v for k, v in n.items() if k in keep_node and v not in ("", [], None)}
+                    for n in graph["nodes"]]
+    out["edges"] = [{k: v for k, v in e.items() if k in ("source", "target", "type", "line")}
+                    for e in graph["edges"]]
+    if "stats" in out:
+        out["stats"] = {k: v for k, v in out["stats"].items() if k != "elapsed_sec"}
+    return out
+
+
+# --------------------------------------------------------------------------------------
+# HTML template (viewer.html, loaded from disk so styling stays editable as real markup)
+# --------------------------------------------------------------------------------------
+
+VIEWER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "viewer.html")
+
+
+def load_template():
+    """Read the viewer shell. Kept as a separate file so CSS/JS edits are plain markup."""
+    try:
+        with open(VIEWER_PATH, "r", encoding="utf-8") as fh:
+            return fh.read()
+    except OSError as exc:
+        raise RuntimeError("cannot read viewer template at %s: %s" % (VIEWER_PATH, exc))
+
+
+
+# --------------------------------------------------------------------------------------
+# Render + atomic delivery
+# --------------------------------------------------------------------------------------
+
+def render_html(graph, title, max_boxes=14):
+    data = slim(graph)
+    # The overview is derived from the FULL graph (before slimming drops fields
+    # it needs), then embedded alongside it as a second, coarser view.
+    try:
+        data["overview"] = overview.build(graph, max_boxes)
+    except Exception as exc:                     # never let the extra view block delivery
+        print("  warning: overview generation failed (%s); explore view only" % exc)
+        data["overview"] = None
+    payload = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+    # Never let the payload terminate the host <script> element.
+    payload = payload.replace("</", "<\\/")
+    html = load_template().replace("__DATA__", payload)
+    return html.replace("__TITLE__", title)
+
+
+def deliver(html, out_path):
+    """Write to a temp file in the SAME directory, then atomically replace the target."""
+    out_dir = os.path.dirname(os.path.abspath(out_path)) or "."
+    os.makedirs(out_dir, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=out_dir, prefix=".codegraph-", suffix=".html")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(html)
+        if "__DATA__" in html or "__TITLE__" in html:
+            raise ValueError("template placeholders left unfilled")
+        os.replace(tmp, out_path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return out_path
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="render.py",
+        description="Render graph.json (+enrich.json) into one self-contained HTML (codegraph stage 3)")
+    ap.add_argument("--in", dest="indir", default=".codegraph",
+                    help="directory containing graph.json (default: .codegraph)")
+    ap.add_argument("--graph", help="explicit path to graph.json (overrides --in)")
+    ap.add_argument("--enrich", help="path to enrich.json (default: <indir>/enrich.json if present)")
+    ap.add_argument("-o", "--out", help="output HTML (default: <indir>/codegraph.html)")
+    ap.add_argument("--title", help="title shown in the artifact (default: project name)")
+    ap.add_argument("--max-boxes", type=int, default=14,
+                    help="module boxes in the overview diagram (default: 14)")
+    ap.add_argument("--validate-only", action="store_true", help="validate inputs, write nothing")
+    ap.add_argument("--strict", action="store_true", help="treat warnings as errors")
+    ap.add_argument("--open", dest="do_open", action="store_true", help="open the result in a browser")
+    args = ap.parse_args(argv)
+
+    gpath = args.graph or os.path.join(args.indir, "graph.json")
+    if not os.path.isfile(gpath):
+        print("error: graph.json not found at %s\n       run scan.py first." % gpath, file=sys.stderr)
+        return 2
+    try:
+        with open(gpath, "r", encoding="utf-8") as fh:
+            graph = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print("error: cannot read %s: %s" % (gpath, exc), file=sys.stderr)
+        return 2
+
+    errors, warnings = validate_graph(graph)
+    if errors:
+        print("VALIDATION FAILED (%d error(s)) — nothing was written:" % len(errors), file=sys.stderr)
+        for e in errors[:20]:
+            print("  - " + e, file=sys.stderr)
+        return 1
+
+    epath = args.enrich or os.path.join(os.path.dirname(gpath) or ".", "enrich.json")
+    enriched = 0
+    if os.path.isfile(epath):
+        try:
+            with open(epath, "r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+            clean, ew = validate_enrich(raw, {n["id"] for n in graph["nodes"]})
+            warnings.extend(ew)
+            graph = merge(graph, clean)
+            enriched = graph.get("enrichedNodes", 0)
+        except ValueError as exc:
+            warnings.append("enrich.json is not valid JSON (%s); rendered without it" % exc)
+    else:
+        warnings.append("no enrich.json found; rendering structure only (no AI summaries/tours)")
+
+    for w in warnings[:20]:
+        print("  warning: " + w)
+    if args.strict and warnings:
+        print("error: --strict and %d warning(s)" % len(warnings), file=sys.stderr)
+        return 1
+
+    if args.validate_only:
+        print("OK: %d nodes, %d edges, %d enriched, %d tour(s)" % (
+            len(graph["nodes"]), len(graph["edges"]), enriched, len(graph.get("tour") or [])))
+        return 0
+
+    out = args.out or os.path.join(os.path.dirname(gpath) or ".", "codegraph.html")
+    title = args.title or graph.get("project", {}).get("name") or "codebase"
+    html = render_html(graph, title, args.max_boxes)
+    deliver(html, out)
+
+    ov = overview.build(graph, args.max_boxes)
+    size_kb = os.path.getsize(out) / 1024.0
+    print("codegraph artifact ready")
+    print("  nodes    : %d   edges: %d" % (len(graph["nodes"]), len(graph["edges"])))
+    if ov:
+        print("  overview : %d modules, %d links, %d-hop journey" % (
+            len(ov["boxes"]), len(ov["edges"]), len(ov["journey"])))
+    docs = graph.get("docSummaries", 0)
+    described = sum(1 for n in graph["nodes"]
+                    if n.get("type") in ("file", "config", "document") and n.get("summary"))
+    total_files = sum(1 for n in graph["nodes"]
+                      if n.get("type") in ("file", "config", "document"))
+    from_doc = sum(1 for n in graph["nodes"] if n.get("summarySource") == "docstring")
+    from_agent = sum(1 for n in graph["nodes"] if n.get("summarySource") == "agent")
+    print("  described: %d/%d files have a summary (%d%%) — %d from docstrings, %d from the agent"
+          % (described, total_files,
+             round(100 * described / total_files) if total_files else 0,
+             from_doc, from_agent))
+    print("  tours    : %d" % len(graph.get("tour") or []))
+    print("  output   : %s (%.0f KB, self-contained)" % (out, size_kb))
+    if args.do_open:
+        webbrowser.open("file://" + os.path.abspath(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/codegraph/scripts/scan.py
+++ b/skills/codegraph/scripts/scan.py
@@ -1,0 +1,1486 @@
+#!/usr/bin/env python3
+"""
+codegraph scan — deterministic codebase -> structural graph extraction.
+
+Stage 1 of 3 in the codegraph pipeline:
+
+    scan.py  ->  graph.json + digest.md        (this file, deterministic)
+    agent    ->  enrich.json                   (semantic layer: summaries, layers, tours)
+    render.py -> codegraph.html                (single self-contained interactive artifact)
+
+Design contract:
+  * ZERO third-party dependencies (stdlib only, Python 3.8+).
+  * Same input -> same output. No LLM calls, no network, no randomness.
+  * Never reads a file twice; caps work on pathological repos.
+  * Emits a compact digest.md so an agent can understand the whole repo
+    WITHOUT loading the (potentially huge) graph.json into its context.
+
+Usage:
+    python3 scan.py [ROOT] [-o OUTDIR] [--max-files N] [--no-calls] [--symbols-for N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+
+SCHEMA_VERSION = "1.0.0"
+
+BACKSLASH = chr(92)
+QUOTE_CHARS = '"' + "'"
+QUOTE_OR_TICK = QUOTE_CHARS + "`"
+
+# --------------------------------------------------------------------------------------
+# Language table
+# --------------------------------------------------------------------------------------
+
+LANG_BY_EXT = {
+    ".py": "python", ".pyi": "python",
+    ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
+    ".ts": "typescript", ".tsx": "typescript", ".mts": "typescript", ".cts": "typescript",
+    ".vue": "vue", ".svelte": "svelte",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java", ".kt": "kotlin", ".kts": "kotlin", ".scala": "scala",
+    ".rb": "ruby",
+    ".php": "php",
+    ".cs": "csharp",
+    ".c": "c", ".h": "c",
+    ".cc": "cpp", ".cpp": "cpp", ".cxx": "cpp", ".hpp": "cpp", ".hh": "cpp",
+    ".swift": "swift",
+    ".m": "objc", ".mm": "objc",
+    ".sh": "shell", ".bash": "shell", ".zsh": "shell",
+    ".sql": "sql",
+    ".tf": "terraform",
+    ".proto": "proto",
+    ".graphql": "graphql", ".gql": "graphql",
+}
+
+# Non-code files worth keeping as graph nodes (config / docs / infra).
+SUPPORT_FILES = {
+    ".json": "config", ".yaml": "config", ".yml": "config", ".toml": "config",
+    ".ini": "config", ".cfg": "config", ".env": "config",
+    ".md": "document", ".mdx": "document", ".rst": "document", ".txt": "document",
+}
+
+DOCKER_NAMES = {"dockerfile", "docker-compose.yml", "docker-compose.yaml", "makefile"}
+
+# Directories never worth walking.
+SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "__pycache__", ".mypy_cache", ".pytest_cache",
+    ".ruff_cache", ".tox", ".nox", "venv", ".venv", "env", ".env.d", "site-packages",
+    "dist", "build", "out", "target", ".next", ".nuxt", ".svelte-kit", ".turbo",
+    "coverage", "htmlcov", ".coverage", ".idea", ".vscode", ".gradle", ".cache",
+    "vendor", "bower_components", "Pods", ".terraform", ".serverless", ".parcel-cache",
+    "codegraph_out", ".codegraph",
+}
+
+SKIP_FILE_RE = re.compile(
+    r"(\.min\.(js|css)$|\.bundle\.js$|-lock\.(json|yaml)$|\.lock$|\.map$|"
+    r"\.snap$|\.pb\.go$|_pb2\.py$|\.generated\.|\.g\.dart$)",
+    re.IGNORECASE,
+)
+
+MAX_FILE_BYTES = 900_000       # skip anything bigger; almost certainly generated
+MAX_LINE_LEN_AVG = 400         # skip minified-looking files
+
+
+# --------------------------------------------------------------------------------------
+# Layer heuristics (the agent may override these in enrich.json)
+# --------------------------------------------------------------------------------------
+
+LAYER_RULES = [
+    ("test",     r"(^|/)(tests?|specs?|__tests__|e2e|fixtures?)(/|$)|(_test|\.test|\.spec|_spec)\."),
+    ("entry",    r"(^|/)(main|index|app|server|cli|__main__|manage|bootstrap|wsgi|asgi)\.[a-z]+$|(^|/)(cmd|bin|scripts?)(/|$)"),
+    ("config",   r"(^|/)(config|configs|settings|conf)(/|$)|(^|/)\.?[a-z]*(rc|config)\.[a-z]+$"),
+    ("infra",    r"(^|/)(deploy|infra|terraform|k8s|kubernetes|helm|\.github|docker)(/|$)|dockerfile|docker-compose"),
+    ("ui",       r"(^|/)(ui|views?|components?|pages?|screens?|templates?|widgets?|styles?|layouts?|themes?)(/|$)"
+                 r"|\.(vue|svelte|tsx|jsx|css|scss)$|(component|view|page|screen|widget|modal|button)s?\.[a-z]+$"),
+    ("api",      r"(^|/)(api|routes?|routers?|controllers?|handlers?|endpoints?|graphql|resolvers?|middleware|rpc|grpc|rest|web|http|server|net|protocols?|transport)(/|$)"
+                 r"|(route|router|controller|handler|endpoint|resolver|middleware|client|server|request|response|session|connection|socket|url)s?\.[a-z]+$"),
+    ("data",     r"(^|/)(models?|entities|schemas?|db|database|migrations?|repositor(y|ies)|dao|store|stores|persistence|dialects?|orm|sql|query|queries|records?|serializers?|codecs?)(/|$)"
+                 r"|(model|entity|schema|table|column|row|record|query|cursor|dialect|serializer|migration|type|types|field)s?\.[a-z]+$"),
+    ("service",  r"(^|/)(services?|domain|core|usecases?|business|logic|managers?|workers?|jobs?|tasks?|agents?|engines?|processors?|pipelines?|events?|commands?)(/|$)"
+                 r"|(service|manager|worker|engine|processor|pipeline|scheduler|dispatcher|executor|runner|event|command|hook)s?\.[a-z]+$"),
+    ("util",     r"(^|/)(utils?|helpers?|lib|libs|common|shared|internal|support|tools?|ext|extensions?|compat|vendor|_compat)(/|$)"
+                 r"|(util|utils|helper|compat|constant|exception|error|log|logger|logging|typing|base|mixin|decorator|context|registry|cache|pool|inspect|inspection|visitor|traversal|annotation|deprecation)s?\.[a-z]+$"),
+    ("docs",     r"(^|/)(docs?|documentation|examples?|samples?)(/|$)|\.(md|mdx|rst)$"),
+]
+
+LAYER_ORDER = ["entry", "ui", "api", "service", "data", "util", "config", "infra", "test", "docs", "other"]
+
+LAYER_LABELS = {
+    "entry": "Entry Points", "ui": "UI / Presentation", "api": "API / Interface",
+    "service": "Business Logic", "data": "Data / Persistence", "util": "Utilities",
+    "config": "Configuration", "infra": "Infrastructure", "test": "Tests",
+    "docs": "Documentation", "other": "Other",
+}
+
+
+def guess_layer(rel_path: str) -> str:
+    low = rel_path.lower()
+    for layer, pattern in LAYER_RULES:
+        if re.search(pattern, low):
+            return layer
+    return "other"
+
+
+# --------------------------------------------------------------------------------------
+# Regex extractors, per language family
+# --------------------------------------------------------------------------------------
+
+RE = {
+    "py_import": re.compile(r"^\s*(?:from\s+([.\w]+)\s+import\s+([^\n#]+)|import\s+([^\n#]+))", re.M),
+    "py_def": re.compile(r"^(?P<indent>[ \t]*)(?:async\s+)?def\s+(?P<name>\w+)\s*\(", re.M),
+    "py_class": re.compile(r"^(?P<indent>[ \t]*)class\s+(?P<name>\w+)\s*[\(:]", re.M),
+
+    "js_import": re.compile(
+        r"""(?:^|\s)import\s+(?:[\w*{}\s,$]+\s+from\s+)?['"]([^'"]+)['"]"""
+        r"""|require\(\s*['"]([^'"]+)['"]\s*\)"""
+        r"""|(?:^|\s)export\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]"""
+        r"""|import\(\s*['"]([^'"]+)['"]\s*\)""",
+        re.M,
+    ),
+    "js_func": re.compile(
+        r"^(?P<indent>[ \t]*)(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s*\*?\s*(?P<name>\w+)",
+        re.M,
+    ),
+    "js_arrow": re.compile(
+        r"^(?P<indent>[ \t]*)(?:export\s+)?(?:default\s+)?(?:const|let|var)\s+(?P<name>\w+)\s*"
+        r"(?::[^=\n]+)?=\s*(?:async\s*)?(?:\([^)]*\)|\w+)\s*=>",
+        re.M,
+    ),
+    "js_class": re.compile(
+        r"^(?P<indent>[ \t]*)(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(?P<name>\w+)"
+        r"(?:\s+extends\s+(?P<base>[\w.]+))?",
+        re.M,
+    ),
+    "js_type": re.compile(
+        r"^(?P<indent>[ \t]*)(?:export\s+)?(?:interface|type|enum)\s+(?P<name>\w+)", re.M),
+    "js_export": re.compile(r"^\s*export\s+(?:default\s+)?(?:const|let|var|function|class|interface|type|enum)?\s*(\w+)?", re.M),
+
+    "go_import_block": re.compile(r"import\s*\(([^)]*)\)", re.S),
+    "go_import_one": re.compile(r'^\s*import\s+(?:[\w.]+\s+)?"([^"]+)"', re.M),
+    "go_import_line": re.compile(r'^\s*(?:[\w.]+\s+)?"([^"]+)"', re.M),
+    "go_func": re.compile(r"^func\s+(?:\((?P<recv>[^)]*)\)\s*)?(?P<name>\w+)\s*[\(\[]", re.M),
+    "go_type": re.compile(r"^type\s+(?P<name>\w+)\s+(?P<kind>struct|interface|func|\w+)", re.M),
+
+    "rs_use": re.compile(r"^\s*(?:pub\s+)?use\s+([^;]+);", re.M),
+    "rs_mod": re.compile(r"^\s*(?:pub\s+)?mod\s+(\w+)\s*;", re.M),
+    "rs_fn": re.compile(r"^(?P<indent>[ \t]*)(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+(?P<name>\w+)", re.M),
+    "rs_type": re.compile(r"^(?P<indent>[ \t]*)(?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait|union)\s+(?P<name>\w+)", re.M),
+    "rs_impl": re.compile(r"^(?P<indent>[ \t]*)impl(?:<[^>]*>)?\s+(?:(?P<trait>[\w:<>]+)\s+for\s+)?(?P<name>[\w:<>]+)", re.M),
+
+    "jvm_import": re.compile(r"^\s*import\s+(?:static\s+)?([\w.]+)(?:\.\*)?\s*;?", re.M),
+    "jvm_pkg": re.compile(r"^\s*package\s+([\w.]+)", re.M),
+    "jvm_type": re.compile(
+        r"^(?P<indent>[ \t]*)(?:public\s+|private\s+|protected\s+|internal\s+|abstract\s+|final\s+|sealed\s+|open\s+|data\s+|static\s+)*"
+        r"(?:class|interface|enum|object|record|trait)\s+(?P<name>\w+)"
+        r"(?:[^\n{]*?(?:extends|:)\s+(?P<base>[\w.<>]+))?",
+        re.M,
+    ),
+    "jvm_method": re.compile(
+        r"^(?P<indent>[ \t]{2,})(?:public\s+|private\s+|protected\s+|internal\s+|static\s+|final\s+|override\s+|suspend\s+|async\s+)*"
+        r"(?:fun\s+(?P<kname>\w+)|(?:[\w<>\[\],?.]+)\s+(?P<jname>\w+)\s*\()",
+        re.M,
+    ),
+
+    "rb_require": re.compile(r"""^\s*require(?:_relative)?\s+['"]([^'"]+)['"]""", re.M),
+    "rb_def": re.compile(r"^(?P<indent>[ \t]*)def\s+(?P<name>[\w.?!=]+)", re.M),
+    "rb_class": re.compile(r"^(?P<indent>[ \t]*)(?:class|module)\s+(?P<name>[\w:]+)(?:\s*<\s*(?P<base>[\w:]+))?", re.M),
+
+    "php_use": re.compile(
+        r"""^\s*(?:use|require(?:_once)?|include(?:_once)?)\s+['"(]?([^'"\s;()]+)""", re.M),
+    "php_def": re.compile(r"^(?P<indent>[ \t]*)(?:(?:public|private|protected|static|abstract|final)\s+)*"
+                          r"(?:function\s+(?P<name>\w+)|(?:class|interface|trait)\s+(?P<cname>\w+))", re.M),
+
+    "cs_using": re.compile(r"^\s*using\s+(?:static\s+)?([\w.]+)\s*;", re.M),
+    "c_include": re.compile(r'^\s*#\s*include\s+[<"]([^>"]+)[>"]', re.M),
+    "c_func": re.compile(r"^(?:[\w*&:<>\[\]]+\s+){1,4}(?P<name>\w+)\s*\([^;]*\)\s*\{", re.M),
+    "c_type": re.compile(r"^(?:typedef\s+)?(?:struct|class|enum|union|namespace)\s+(?P<name>\w+)", re.M),
+
+    "swift_import": re.compile(r"^\s*import\s+(\w+)", re.M),
+    "swift_def": re.compile(r"^(?P<indent>[ \t]*)(?:public\s+|private\s+|internal\s+|open\s+|final\s+|static\s+)*"
+                            r"(?:func\s+(?P<name>\w+)|(?:class|struct|enum|protocol|extension)\s+(?P<cname>\w+))", re.M),
+
+    "sh_source": re.compile(r"^\s*(?:source|\.)\s+([\w./$-]+)", re.M),
+    "sh_func": re.compile(r"^(?:function\s+)?(?P<name>[\w-]+)\s*\(\)\s*\{", re.M),
+
+    "tf_resource": re.compile(r'^(resource|module|data)\s+"([^"]+)"(?:\s+"([^"]+)")?', re.M),
+    "sql_def": re.compile(r"CREATE\s+(?:OR\s+REPLACE\s+)?(TABLE|VIEW|INDEX|FUNCTION|PROCEDURE)\s+"
+                          r"""(?:IF\s+NOT\s+EXISTS\s+)?[`"\[]?([\w.]+)""", re.I),
+    "gql_def": re.compile(r"^\s*(type|input|enum|interface|union|scalar)\s+(\w+)", re.M),
+    "proto_def": re.compile(r"^\s*(message|service|enum)\s+(\w+)", re.M),
+
+    "vue_script": re.compile(r"<script[^>]*>(.*?)</script>", re.S),
+    # Only trust route strings that appear in a real route-declaration context,
+    # otherwise docstrings and example URLs create phantom entry points.
+    "route_str": re.compile(
+        r"""(?:@(?:\w+\.)*(?:route|get|post|put|patch|delete|api_route)|"""
+        r"""\.(?:route|get|post|put|patch|delete|use|all)|"""
+        r"""(?:^|\s)(?:path|url|re_path|Route|HandleFunc|register|add_url_rule))"""
+        r"""\s*\(\s*[^)"']*["'](/[\w:{}\-./]*)["']""",
+        re.M,
+    ),
+    "http_verb": re.compile(r"\.(get|post|put|patch|delete|head|options)\s*\(", re.I),
+}
+
+# Identifiers too generic to trust for cross-file call inference.
+CALL_STOPWORDS = {
+    "main", "run", "get", "set", "init", "test", "log", "print", "error", "data", "value",
+    "name", "type", "id", "self", "this", "new", "add", "list", "map", "filter", "reduce",
+    "start", "stop", "close", "open", "read", "write", "send", "load", "save", "next",
+    "then", "catch", "push", "pop", "call", "apply", "bind", "keys", "items", "length",
+    "string", "number", "object", "array", "boolean", "true", "false", "none", "null",
+    "config", "options", "params", "args", "kwargs", "result", "response", "request",
+    "create", "update", "delete", "remove", "find", "parse", "format", "build", "make",
+    "handle", "process", "execute", "validate", "check", "render", "setup", "clone",
+}
+
+IDENT_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]{3,}\b")
+COMMENT_STRIP = {
+    "hash": re.compile(r"#.*$", re.M),
+    "slash": re.compile(r"//.*$|/\*.*?\*/", re.M | re.S),
+}
+
+
+# --------------------------------------------------------------------------------------
+# File discovery
+# --------------------------------------------------------------------------------------
+
+def git_tracked_files(root: str):
+    """Use git for discovery when available: respects .gitignore exactly, and is fast."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, "ls-files", "--cached", "--others", "--exclude-standard"],
+            capture_output=True, text=True, timeout=45,
+        )
+        if out.returncode != 0:
+            return None
+        files = [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+        return files or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def walk_files(root: str):
+    found = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".")
+                       or d in (".github",)]
+        for fn in filenames:
+            full = os.path.join(dirpath, fn)
+            found.append(os.path.relpath(full, root))
+    return found
+
+
+def classify(rel_path: str):
+    """Return (kind, language) or (None, None) if the file should be ignored."""
+    base = os.path.basename(rel_path).lower()
+    ext = os.path.splitext(base)[1]
+    if SKIP_FILE_RE.search(base):
+        return None, None
+    if any(part in SKIP_DIRS for part in rel_path.split(os.sep)[:-1]):
+        return None, None
+    if ext in LANG_BY_EXT:
+        return "code", LANG_BY_EXT[ext]
+    if base in DOCKER_NAMES or base.startswith("dockerfile"):
+        return "infra", "docker"
+    if ext in SUPPORT_FILES:
+        return SUPPORT_FILES[ext], "text"
+    return None, None
+
+
+def read_text(path: str):
+    try:
+        if os.path.getsize(path) > MAX_FILE_BYTES:
+            return None
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+# --------------------------------------------------------------------------------------
+# Symbol / import extraction
+# --------------------------------------------------------------------------------------
+
+def _block_end_by_indent(lines, start_idx: int, indent: str) -> int:
+    """End line (1-based) of an indentation-delimited block (Python/Ruby-ish)."""
+    base = len(indent.expandtabs(4))
+    last = start_idx
+    for i in range(start_idx + 1, len(lines)):
+        line = lines[i]
+        if not line.strip():
+            continue
+        cur = len(line[: len(line) - len(line.lstrip())].expandtabs(4))
+        if cur <= base:
+            break
+        last = i
+    return last + 1
+
+
+def _block_end_by_brace(text: str, start_pos: int, max_lines: int = 4000) -> int:
+    """End line (1-based) of a brace-delimited block starting at/after start_pos."""
+    depth = 0
+    seen = False
+    i = start_pos
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+            seen = True
+        elif ch == "}":
+            depth -= 1
+            if seen and depth <= 0:
+                return text.count("\n", 0, i) + 1
+        elif ch in QUOTE_OR_TICK:
+            quote = ch
+            i += 1
+            while i < n and text[i] != quote:
+                if text[i] == BACKSLASH:
+                    i += 1
+                i += 1
+        i += 1
+    return min(text.count("\n", 0, start_pos) + 1 + max_lines, text.count("\n") + 1)
+
+
+def line_of(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+# --------------------------------------------------------------------------------------
+# Self-documentation: most codebases already describe themselves in docstrings and
+# file-header comments. Reading them costs nothing and is the difference between a
+# node that says "1674 LOC" and one that says what the file is FOR.
+# --------------------------------------------------------------------------------------
+
+_PY_DOC = re.compile(r'^\s*(?:[rubRUB]{0,2})("""|\'\'\')(.*?)\1', re.S)
+_BLOCK_DOC = re.compile(r'^\s*/\*\*?(.*?)\*/', re.S)
+_LINE_DOC = re.compile(r'^((?:\s*(?://|#|--)[^\n]*\n)+)')
+_NOISE = re.compile(r'^(#!|-\*-|coding[:=]|type:\s*ignore|eslint|prettier|@ts-|flake8|noqa|'
+                    r'pylint|mypy|ruff|fmt:|Copyright|SPDX|Licensed|All rights)', re.I)
+
+
+def _clean_doc(raw: str) -> str:
+    """Collapse a docstring/comment block into one useful sentence."""
+    lines = []
+    for ln in raw.split("\n"):
+        ln = ln.strip()
+        ln = re.sub(r'^(?://+|#+|--+|\*+)\s?', "", ln).strip()
+        if not ln or _NOISE.match(ln):
+            continue
+        # Stop at structured sections; the prose above them is the summary.
+        if re.match(r'^(Args|Arguments|Returns|Raises|Yields|Example[s]?|Note[s]?|'
+                    r'Usage|Attributes|Params?|TODO|FIXME)\s*:?\s*$', ln, re.I):
+            break
+        if re.match(r'^[-=~#*_]{3,}$', ln):        # rule lines
+            continue
+        lines.append(ln)
+        if len(" ".join(lines)) > 400:
+            break
+    doc = " ".join(lines).strip()
+    if not doc:
+        return ""
+    # Prefer the first 1-2 sentences: a node tooltip is not a manual.
+    parts = re.split(r'(?<=[.!?。])\s+', doc)
+    out = parts[0]
+    if len(out) < 60 and len(parts) > 1:
+        out += " " + parts[1]
+    return out[:260].strip()
+
+
+def extract_doc(language: str, text: str) -> str:
+    """Best-effort 'what is this file' sentence, taken from the code itself."""
+    head = text[:4000]
+    if language == "python":
+        m = _PY_DOC.match(head)
+        if m:
+            return _clean_doc(m.group(2))
+        # No module docstring: fall back to the first class/def that has one.
+        m = re.search(r'^\s*(?:async\s+)?(?:def|class)\s+\w+[^\n]*:\s*\n\s*("""|\'\'\')(.*?)\1',
+                      head, re.S | re.M)
+        if m:
+            return _clean_doc(m.group(2))
+        return ""
+    if language in ("javascript", "typescript", "vue", "svelte", "go", "rust", "java",
+                    "kotlin", "scala", "csharp", "c", "cpp", "objc", "swift", "php"):
+        m = _BLOCK_DOC.match(head)
+        if m:
+            return _clean_doc(m.group(1))
+        m = _LINE_DOC.match(head)
+        if m:
+            return _clean_doc(m.group(1))
+        # Doc comment attached to the first declaration rather than the file top.
+        m = re.search(r'(/\*\*(?:[^*]|\*(?!/))*\*/)\s*(?:export\s+)?'
+                      r'(?:async\s+)?(?:function|class|const|interface|type|func|pub|struct)',
+                      head)
+        if m:
+            return _clean_doc(m.group(1)[3:-2])
+        return ""
+    if language in ("shell", "ruby", "terraform"):
+        m = _LINE_DOC.match(head)
+        if m:
+            return _clean_doc(m.group(1))
+    return ""
+
+
+def extract(language: str, text: str, rel_path: str):
+    """Return dict(imports=[raw specifiers], defs=[{kind,name,line,end_line,base}], extras={})."""
+    imports = []
+    defs = []
+    extras = {}
+    lines = text.split("\n")
+
+    def add_def(kind, name, pos, end_line=None, base=None, indent=""):
+        if not name:
+            return
+        start = line_of(text, pos)
+        if end_line is None:
+            end_line = _block_end_by_brace(text, pos) if language not in ("python", "ruby") \
+                else _block_end_by_indent(lines, start - 1, indent)
+        defs.append({
+            "kind": kind, "name": name, "line": start,
+            "end_line": max(end_line, start), "base": base,
+            "top": len(indent.expandtabs(4)) == 0,
+        })
+
+    if language == "vue" or language == "svelte":
+        blocks = RE["vue_script"].findall(text)
+        inner = "\n".join(blocks) if blocks else ""
+        for m in RE["js_import"].finditer(inner or text):
+            imports.append(next(g for g in m.groups() if g))
+        language = "typescript" if 'lang="ts"' in text or "lang='ts'" in text else "javascript"
+        text_for_defs = inner or text
+        for key, kind in (("js_func", "function"), ("js_arrow", "function"),
+                          ("js_class", "class"), ("js_type", "type")):
+            for m in RE[key].finditer(text_for_defs):
+                add_def(kind, m.group("name"), text.find(m.group(0)) if inner else m.start(),
+                        indent=m.groupdict().get("indent", ""))
+        return {"imports": imports, "defs": defs, "extras": extras}
+
+    if language == "python":
+        for m in RE["py_import"].finditer(text):
+            frm, _names, plain = m.group(1), m.group(2), m.group(3)
+            if frm:
+                imports.append(frm)
+            elif plain:
+                for part in plain.split(","):
+                    mod = part.strip().split(" as ")[0].strip()
+                    if mod:
+                        imports.append(mod)
+        for key, kind in (("py_class", "class"), ("py_def", "function")):
+            for m in RE[key].finditer(text):
+                add_def(kind, m.group("name"), m.start(), indent=m.group("indent"))
+
+    elif language in ("javascript", "typescript"):
+        for m in RE["js_import"].finditer(text):
+            spec = next((g for g in m.groups() if g), None)
+            if spec:
+                imports.append(spec)
+        for key, kind in (("js_func", "function"), ("js_arrow", "function"),
+                          ("js_class", "class"), ("js_type", "type")):
+            for m in RE[key].finditer(text):
+                add_def(kind, m.group("name"), m.start(),
+                        base=m.groupdict().get("base"), indent=m.group("indent"))
+        verbs = RE["http_verb"].findall(text)
+        if verbs:
+            extras["http_verbs"] = sorted(set(v.lower() for v in verbs))
+
+    elif language == "go":
+        blocks = RE["go_import_block"].findall(text)
+        for blk in blocks:
+            imports.extend(RE["go_import_line"].findall(blk))
+        imports.extend(RE["go_import_one"].findall(text))
+        for m in RE["go_func"].finditer(text):
+            recv = (m.group("recv") or "").split()
+            owner = recv[-1].lstrip("*") if recv else None
+            add_def("method" if owner else "function", m.group("name"), m.start(), base=owner)
+        for m in RE["go_type"].finditer(text):
+            add_def("class" if m.group("kind") in ("struct", "interface") else "type",
+                    m.group("name"), m.start())
+
+    elif language == "rust":
+        for m in RE["rs_use"].finditer(text):
+            imports.append(m.group(1).strip().split(" as ")[0])
+        for name in RE["rs_mod"].findall(text):
+            imports.append("mod::" + name)
+        for key, kind in (("rs_fn", "function"), ("rs_type", "class"), ("rs_impl", "impl")):
+            for m in RE[key].finditer(text):
+                add_def(kind, m.group("name"), m.start(),
+                        base=m.groupdict().get("trait"), indent=m.group("indent"))
+
+    elif language in ("java", "kotlin", "scala"):
+        imports.extend(RE["jvm_import"].findall(text))
+        pkg = RE["jvm_pkg"].search(text)
+        if pkg:
+            extras["package"] = pkg.group(1)
+        for m in RE["jvm_type"].finditer(text):
+            add_def("class", m.group("name"), m.start(),
+                    base=m.groupdict().get("base"), indent=m.group("indent"))
+        for m in RE["jvm_method"].finditer(text):
+            add_def("method", m.group("kname") or m.group("jname"), m.start(),
+                    indent=m.group("indent"))
+
+    elif language == "ruby":
+        imports.extend(RE["rb_require"].findall(text))
+        for key, kind in (("rb_class", "class"), ("rb_def", "function")):
+            for m in RE[key].finditer(text):
+                add_def(kind, m.group("name"), m.start(),
+                        base=m.groupdict().get("base"), indent=m.group("indent"))
+
+    elif language == "php":
+        imports.extend(RE["php_use"].findall(text))
+        for m in RE["php_def"].finditer(text):
+            add_def("class" if m.group("cname") else "function",
+                    m.group("cname") or m.group("name"), m.start(), indent=m.group("indent"))
+
+    elif language == "csharp":
+        imports.extend(RE["cs_using"].findall(text))
+        for m in RE["jvm_type"].finditer(text):
+            add_def("class", m.group("name"), m.start(),
+                    base=m.groupdict().get("base"), indent=m.group("indent"))
+        for m in RE["jvm_method"].finditer(text):
+            add_def("method", m.group("kname") or m.group("jname"), m.start(),
+                    indent=m.group("indent"))
+
+    elif language in ("c", "cpp", "objc"):
+        imports.extend(RE["c_include"].findall(text))
+        for m in RE["c_type"].finditer(text):
+            add_def("class", m.group("name"), m.start())
+        for m in RE["c_func"].finditer(text):
+            add_def("function", m.group("name"), m.start())
+
+    elif language == "swift":
+        imports.extend(RE["swift_import"].findall(text))
+        for m in RE["swift_def"].finditer(text):
+            add_def("class" if m.group("cname") else "function",
+                    m.group("cname") or m.group("name"), m.start(), indent=m.group("indent"))
+
+    elif language == "shell":
+        imports.extend(RE["sh_source"].findall(text))
+        for m in RE["sh_func"].finditer(text):
+            add_def("function", m.group("name"), m.start())
+
+    elif language == "terraform":
+        for kind, a, b in RE["tf_resource"].findall(text):
+            add_def("resource", (b or a), text.find(a))
+
+    elif language == "sql":
+        for kind, name in RE["sql_def"].findall(text):
+            add_def("table" if kind.upper() in ("TABLE", "VIEW") else "function", name,
+                    text.lower().find(name.lower()))
+
+    elif language == "graphql":
+        for kind, name in RE["gql_def"].findall(text):
+            add_def("schema", name, text.find(name))
+
+    elif language == "proto":
+        for kind, name in RE["proto_def"].findall(text):
+            add_def("service" if kind == "service" else "schema", name, text.find(name))
+
+    # Route strings are a strong signal of "this file is an entry surface".
+    if language in ("python", "javascript", "typescript", "go", "ruby", "php", "java", "kotlin"):
+        routes = [r for r in RE["route_str"].findall(text)
+                  if 1 < len(r) < 60 and "//" not in r][:12]
+        if routes:
+            extras["routes"] = sorted(set(routes))
+
+    return {"imports": imports, "defs": defs, "extras": extras}
+
+
+# --------------------------------------------------------------------------------------
+# Import resolution
+# --------------------------------------------------------------------------------------
+
+JS_EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".vue", ".svelte", ".mts", ".cts"]
+SRC_ROOTS = ["", "src", "lib", "app", "source", "packages", "internal", "pkg", "server", "client"]
+
+
+class Resolver:
+    def __init__(self, root: str, files):
+        self.root = root
+        self.files = set(files)
+        self.by_basename = defaultdict(list)
+        self.by_stem = defaultdict(list)
+        for f in files:
+            base = os.path.basename(f)
+            self.by_basename[base].append(f)
+            self.by_stem[os.path.splitext(base)[0]].append(f)
+        self.go_module = self._go_module()
+        self.dirs = {os.path.dirname(f) for f in files}
+
+    def _go_module(self):
+        gomod = os.path.join(self.root, "go.mod")
+        if os.path.exists(gomod):
+            try:
+                with open(gomod, "r", encoding="utf-8", errors="replace") as fh:
+                    for line in fh:
+                        if line.startswith("module "):
+                            return line.split(None, 1)[1].strip()
+            except OSError:
+                pass
+        return None
+
+    def _norm(self, p: str):
+        p = os.path.normpath(p).replace(os.sep, "/")
+        return p[2:] if p.startswith("./") else p
+
+    def _exists(self, cand: str):
+        cand = self._norm(cand)
+        return cand if cand in self.files else None
+
+    def _try_exts(self, base: str):
+        base = self._norm(base)
+        hit = self._exists(base)
+        if hit:
+            return hit
+        for ext in JS_EXTS + [".py", ".go", ".rs", ".rb", ".php"]:
+            hit = self._exists(base + ext)
+            if hit:
+                return hit
+        for ext in JS_EXTS:
+            hit = self._exists(base + "/index" + ext)
+            if hit:
+                return hit
+        for name in ("__init__.py", "mod.rs", "lib.rs"):
+            hit = self._exists(base + "/" + name)
+            if hit:
+                return hit
+        return None
+
+    def resolve(self, spec: str, from_file: str, language: str):
+        """Return (resolved_rel_path | None, external_name | None)."""
+        spec = spec.strip().strip(QUOTE_CHARS)
+        if not spec:
+            return None, None
+        here = os.path.dirname(from_file)
+
+        # Relative paths (JS/TS/Python-dot/shell/C-include)
+        if spec.startswith("."):
+            if language == "python":
+                dots = len(spec) - len(spec.lstrip("."))
+                up = here
+                for _ in range(dots - 1):
+                    up = os.path.dirname(up)
+                tail = spec[dots:].replace(".", "/")
+                return self._try_exts(os.path.join(up, tail) if tail else up), None
+            return self._try_exts(os.path.join(here, spec)), None
+
+        if language == "python":
+            tail = spec.replace(".", "/")
+            for sr in SRC_ROOTS:
+                hit = self._try_exts(os.path.join(sr, tail) if sr else tail)
+                if hit:
+                    return hit, None
+            return None, spec.split(".")[0]
+
+        if language in ("javascript", "typescript", "vue", "svelte"):
+            if spec.startswith("@/") or spec.startswith("~/") or spec.startswith("#"):
+                tail = spec[2:] if spec[1] == "/" else spec[1:]
+                for sr in ("src", "app", "lib", ""):
+                    hit = self._try_exts(os.path.join(sr, tail) if sr else tail)
+                    if hit:
+                        return hit, None
+                return None, spec
+            # Bare specifier that happens to match an internal path (monorepo/baseUrl).
+            for sr in ("", "src", "lib", "app", "packages"):
+                cand = os.path.join(sr, spec) if sr else spec
+                if cand.replace(os.sep, "/").split("/")[0] in self.dirs or True:
+                    hit = self._try_exts(cand)
+                    if hit:
+                        return hit, None
+            ext_name = "/".join(spec.split("/")[:2]) if spec.startswith("@") else spec.split("/")[0]
+            return None, ext_name
+
+        if language == "go":
+            if spec.startswith("mod::"):
+                return None, None
+            if self.go_module and spec.startswith(self.go_module):
+                tail = spec[len(self.go_module):].lstrip("/")
+                cand_dir = tail
+                pkg_files = [f for f in self.files
+                             if os.path.dirname(f).replace(os.sep, "/") == cand_dir and f.endswith(".go")]
+                if pkg_files:
+                    return sorted(pkg_files)[0], None
+            if "." in spec.split("/")[0]:
+                return None, "/".join(spec.split("/")[:3])
+            return None, spec.split("/")[0]
+
+        if language == "rust":
+            if spec.startswith("mod::"):
+                name = spec[5:]
+                for cand in (os.path.join(here, name + ".rs"), os.path.join(here, name, "mod.rs")):
+                    hit = self._exists(cand)
+                    if hit:
+                        return hit, None
+                return None, None
+            parts = [p for p in re.split(r"::", spec) if p and p not in ("{", "}")]
+            if not parts:
+                return None, None
+            if parts[0] in ("crate", "self", "super"):
+                tail = "/".join(parts[1:])
+                for sr in ("src", ""):
+                    hit = self._try_exts(os.path.join(sr, tail) if sr else tail)
+                    if hit:
+                        return hit, None
+                return None, None
+            if parts[0] == "std" or parts[0] == "core" or parts[0] == "alloc":
+                return None, "std"
+            return None, parts[0]
+
+        if language in ("java", "kotlin", "scala", "csharp"):
+            parts = spec.split(".")
+            cls = parts[-1]
+            path_hint = "/".join(parts).lower()
+            for cand in self.by_stem.get(cls, []):
+                if cand.lower().replace(os.sep, "/").endswith(path_hint + ".java") or \
+                   cand.lower().replace(os.sep, "/").endswith(path_hint + ".kt") or \
+                   cand.lower().replace(os.sep, "/").endswith(path_hint + ".scala") or \
+                   cand.lower().replace(os.sep, "/").endswith(path_hint + ".cs"):
+                    return cand, None
+            if len(self.by_stem.get(cls, [])) == 1:
+                return self.by_stem[cls][0], None
+            return None, ".".join(parts[:2])
+
+        if language in ("c", "cpp", "objc"):
+            hit = self._try_exts(os.path.join(here, spec)) or self._exists(spec)
+            if hit:
+                return hit, None
+            cands = self.by_basename.get(os.path.basename(spec), [])
+            return (cands[0], None) if len(cands) == 1 else (None, spec)
+
+        if language in ("ruby", "php", "shell"):
+            hit = self._try_exts(os.path.join(here, spec)) or self._try_exts(spec)
+            if hit:
+                return hit, None
+            for sr in ("lib", "app", "src", ""):
+                hit = self._try_exts(os.path.join(sr, spec) if sr else spec)
+                if hit:
+                    return hit, None
+            return None, spec.split("/")[0]
+
+        return None, None
+
+
+# --------------------------------------------------------------------------------------
+# Graph metrics
+# --------------------------------------------------------------------------------------
+
+def pagerank(node_ids, out_edges, damping=0.85, iters=25):
+    n = len(node_ids)
+    if n == 0:
+        return {}
+    idx = {nid: i for i, nid in enumerate(node_ids)}
+    outs = [[] for _ in range(n)]
+    for src, targets in out_edges.items():
+        if src not in idx:
+            continue
+        outs[idx[src]] = [idx[t] for t in targets if t in idx]
+    rank = [1.0 / n] * n
+    for _ in range(iters):
+        nxt = [(1.0 - damping) / n] * n
+        sink = 0.0
+        for i in range(n):
+            if not outs[i]:
+                sink += rank[i]
+                continue
+            share = damping * rank[i] / len(outs[i])
+            for j in outs[i]:
+                nxt[j] += share
+        if sink:
+            add = damping * sink / n
+            nxt = [v + add for v in nxt]
+        rank = nxt
+    return {nid: rank[idx[nid]] for nid in node_ids}
+
+
+def find_cycles(node_ids, out_edges, limit=25):
+    """Tarjan SCC, iterative (no recursion limit risk on big graphs)."""
+    index = {}
+    low = {}
+    on_stack = set()
+    stack = []
+    result = []
+    counter = [0]
+
+    for root in node_ids:
+        if root in index:
+            continue
+        work = [(root, iter(out_edges.get(root, ())))]
+        index[root] = low[root] = counter[0]
+        counter[0] += 1
+        stack.append(root)
+        on_stack.add(root)
+        while work:
+            node, it = work[-1]
+            advanced = False
+            for succ in it:
+                if succ not in index:
+                    index[succ] = low[succ] = counter[0]
+                    counter[0] += 1
+                    stack.append(succ)
+                    on_stack.add(succ)
+                    work.append((succ, iter(out_edges.get(succ, ()))))
+                    advanced = True
+                    break
+                if succ in on_stack:
+                    low[node] = min(low[node], index[succ])
+            if advanced:
+                continue
+            work.pop()
+            if work:
+                parent = work[-1][0]
+                low[parent] = min(low[parent], low[node])
+            if low[node] == index[node]:
+                comp = []
+                while True:
+                    w = stack.pop()
+                    on_stack.discard(w)
+                    comp.append(w)
+                    if w == node:
+                        break
+                if len(comp) > 1:
+                    result.append(sorted(comp))
+    result.sort(key=len, reverse=True)
+    return result[:limit]
+
+
+# --------------------------------------------------------------------------------------
+# Main scan
+# --------------------------------------------------------------------------------------
+
+def detect_frameworks(root: str, files):
+    hints = []
+    fset = set(files)
+
+    def read(name):
+        p = os.path.join(root, name)
+        if os.path.exists(p):
+            return read_text(p) or ""
+        return ""
+
+    pkg = read("package.json")
+    if pkg:
+        for name, label in [
+            ('"next"', "Next.js"), ('"react"', "React"), ('"vue"', "Vue"),
+            ('"svelte"', "Svelte"), ('"@angular/core"', "Angular"),
+            ('"express"', "Express"), ('"fastify"', "Fastify"), ('"nest', "NestJS"),
+            ('"vite"', "Vite"), ('"webpack"', "Webpack"), ('"jest"', "Jest"),
+            ('"vitest"', "Vitest"), ('"tailwindcss"', "Tailwind"),
+            ('"prisma"', "Prisma"), ('"electron"', "Electron"),
+        ]:
+            if name in pkg:
+                hints.append(label)
+    reqs = read("requirements.txt") + read("pyproject.toml") + read("setup.py") + read("Pipfile")
+    if reqs:
+        for name, label in [
+            ("django", "Django"), ("flask", "Flask"), ("fastapi", "FastAPI"),
+            ("torch", "PyTorch"), ("tensorflow", "TensorFlow"), ("pandas", "pandas"),
+            ("sqlalchemy", "SQLAlchemy"), ("pydantic", "Pydantic"), ("celery", "Celery"),
+            ("pytest", "pytest"), ("langchain", "LangChain"), ("transformers", "Transformers"),
+        ]:
+            if name in reqs.lower():
+                hints.append(label)
+    if "go.mod" in fset:
+        hints.append("Go modules")
+    if "Cargo.toml" in fset:
+        hints.append("Cargo")
+    if "pom.xml" in fset:
+        hints.append("Maven")
+    if any(f in fset for f in ("build.gradle", "build.gradle.kts")):
+        hints.append("Gradle")
+    if "Gemfile" in fset:
+        hints.append("Bundler")
+    if any(f.lower().startswith("dockerfile") for f in fset):
+        hints.append("Docker")
+    if any(f.startswith(".github/workflows/") for f in fset):
+        hints.append("GitHub Actions")
+    seen = []
+    for h in hints:
+        if h not in seen:
+            seen.append(h)
+    return seen
+
+
+def entry_point_score(rel_path: str, extras: dict, language: str) -> int:
+    score = 0
+    low = rel_path.lower()
+    base = os.path.basename(low)
+    stem = os.path.splitext(base)[0]
+    if stem in ("main", "__main__", "index", "app", "server", "cli", "manage", "wsgi", "asgi", "bootstrap"):
+        score += 5
+    if re.match(r"^(cmd|bin|scripts?)/", low):
+        score += 3
+    # Routes are context-verified; http_verbs alone are too weak a signal
+    # (".get(" matches ordinary dict access), so they only reinforce routes.
+    if extras.get("routes"):
+        score += 3
+        if extras.get("http_verbs"):
+            score += 1
+    if low.count("/") == 0:
+        score += 1
+    if re.search(r"(^|/)(tests?|__tests__)/", low):
+        score -= 6
+    return score
+
+
+def git_commit(root: str) -> str:
+    try:
+        out = subprocess.run(["git", "-C", root, "rev-parse", "--short", "HEAD"],
+                             capture_output=True, text=True, timeout=15)
+        return out.stdout.strip() if out.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def scan(root: str, max_files: int, want_calls: bool, symbols_for: int):
+    root = os.path.abspath(root)
+    started = time.time()
+
+    candidates = git_tracked_files(root)
+    discovery = "git"
+    if candidates is None:
+        candidates = walk_files(root)
+        discovery = "walk"
+
+    kept = []
+    skipped_big = 0
+    for rel in candidates:
+        rel = rel.replace(os.sep, "/")
+        kind, lang = classify(rel)
+        if kind is None:
+            continue
+        full = os.path.join(root, rel)
+        if not os.path.isfile(full):
+            continue
+        try:
+            if os.path.getsize(full) > MAX_FILE_BYTES:
+                skipped_big += 1
+                continue
+        except OSError:
+            continue
+        kept.append((rel, kind, lang))
+
+    # Prefer real code when we must truncate.
+    kept.sort(key=lambda t: (t[1] != "code", t[0].count("/"), t[0]))
+    truncated = len(kept) > max_files
+    if truncated:
+        kept = kept[:max_files]
+
+    all_rel = [k[0] for k in kept]
+    resolver = Resolver(root, all_rel)
+
+    files = {}
+    for rel, kind, lang in kept:
+        text = read_text(os.path.join(root, rel))
+        if text is None:
+            continue
+        nlines = text.count("\n") + 1
+        if nlines and len(text) / nlines > MAX_LINE_LEN_AVG and nlines < 50:
+            continue  # minified-looking
+        info = {"rel": rel, "kind": kind, "lang": lang, "loc": nlines, "bytes": len(text)}
+        if kind == "code":
+            ex = extract(lang, text, rel)
+            info["raw_imports"] = ex["imports"]
+            info["defs"] = ex["defs"]
+            info["extras"] = ex["extras"]
+            # The file's own words about itself — free, and covers ~94% of a
+            # well-documented repo without any model involvement.
+            info["doc"] = extract_doc(lang, text)
+        else:
+            info["raw_imports"] = []
+            info["defs"] = []
+            info["extras"] = {}
+            if kind == "document":
+                first = next((ln.strip("# ").strip() for ln in text.split("\n")[:20] if ln.strip()), "")
+                info["extras"]["title"] = first[:120]
+        info["text_cache"] = text if want_calls and kind == "code" else None
+        files[rel] = info
+
+    # ---- edges: imports -------------------------------------------------------------
+    import_edges = []           # (src_rel, dst_rel)
+    externals = Counter()
+    external_users = defaultdict(set)
+    unresolved = Counter()
+    for rel, info in files.items():
+        seen_targets = set()
+        for spec in info["raw_imports"]:
+            dst, ext = resolver.resolve(spec, rel, info["lang"])
+            if dst and dst in files and dst != rel:
+                if dst not in seen_targets:
+                    seen_targets.add(dst)
+                    import_edges.append((rel, dst))
+            elif ext:
+                externals[ext] += 1
+                external_users[ext].add(rel)
+            elif dst is None:
+                unresolved[spec.split("/")[0][:40]] += 1
+        info["imports_resolved"] = sorted(seen_targets)
+
+    out_map = defaultdict(list)
+    in_map = defaultdict(list)
+    for s, d in import_edges:
+        out_map[s].append(d)
+        in_map[d].append(s)
+
+    ranks = pagerank(list(files.keys()), out_map)
+    cycles = find_cycles(list(files.keys()), out_map)
+
+    # ---- importance & entry points --------------------------------------------------
+    max_rank = max(ranks.values()) if ranks else 1.0
+    for rel, info in files.items():
+        fan_in = len(in_map.get(rel, []))
+        fan_out = len(out_map.get(rel, []))
+        info["fan_in"] = fan_in
+        info["fan_out"] = fan_out
+        norm_rank = ranks.get(rel, 0.0) / max_rank if max_rank else 0.0
+        size_factor = min(info["loc"] / 400.0, 1.0)
+        info["importance"] = round(
+            0.55 * norm_rank + 0.25 * min(fan_in / 12.0, 1.0) + 0.20 * size_factor, 4)
+        info["entry_score"] = entry_point_score(rel, info["extras"], info["lang"])
+        info["layer"] = guess_layer(rel)
+
+    entries = sorted(
+        [r for r, i in files.items() if i["entry_score"] >= 3],
+        key=lambda r: (-files[r]["entry_score"], -files[r]["importance"], r),
+    )[:20]
+    for r in entries:
+        if files[r]["layer"] not in ("test", "docs"):
+            files[r]["layer"] = "entry" if files[r]["entry_score"] >= 5 else files[r]["layer"]
+
+    # ---- symbol nodes ---------------------------------------------------------------
+    ranked_files = sorted(files.values(), key=lambda i: -i["importance"])
+    symbol_hosts = {i["rel"] for i in ranked_files[:symbols_for]}
+    symbols = {}   # sym_id -> record
+    for rel in symbol_hosts:
+        info = files[rel]
+        tops = [d for d in info["defs"] if d.get("top")] or info["defs"]
+        tops = sorted(tops, key=lambda d: -(d["end_line"] - d["line"]))[:24]
+        for d in tops:
+            sid = "sym:%s#%s:%d" % (rel, d["name"], d["line"])
+            symbols[sid] = {
+                "id": sid, "file": rel, "name": d["name"], "kind": d["kind"],
+                "line": d["line"], "end_line": d["end_line"], "base": d.get("base"),
+                "size": max(1, d["end_line"] - d["line"] + 1),
+            }
+
+    # ---- call edges (heuristic, bounded) -------------------------------------------
+    call_edges = []
+    if want_calls and symbols:
+        by_name = defaultdict(list)
+        for sid, s in symbols.items():
+            nm = s["name"]
+            if len(nm) >= 4 and nm.lower() not in CALL_STOPWORDS:
+                by_name[nm].append(sid)
+        unique_names = {nm: sids[0] for nm, sids in by_name.items() if len(sids) == 1}
+        for rel, info in files.items():
+            text = info.get("text_cache")
+            if not text:
+                continue
+            stripper = COMMENT_STRIP["hash"] if info["lang"] in ("python", "ruby", "shell") \
+                else COMMENT_STRIP["slash"]
+            body = stripper.sub("", text)
+            local_syms = sorted(
+                [s for s in symbols.values() if s["file"] == rel],
+                key=lambda s: s["line"])
+            hits = set()
+            for m in IDENT_RE.finditer(body):
+                nm = m.group(0)
+                target = unique_names.get(nm)
+                if not target or symbols[target]["file"] == rel:
+                    continue
+                ln = body.count("\n", 0, m.start()) + 1
+                caller = None
+                for s in local_syms:
+                    if s["line"] <= ln <= s["end_line"]:
+                        caller = s["id"]
+                source = caller or rel
+                if (source, target) in hits:
+                    continue
+                hits.add((source, target))
+                call_edges.append((source, target, ln))
+            if len(call_edges) > 40000:
+                break
+
+    for info in files.values():
+        info.pop("text_cache", None)
+
+    stats = {
+        "discovery": discovery,
+        "files_considered": len(candidates),
+        "files_indexed": len(files),
+        "files_skipped_large": skipped_big,
+        "truncated": truncated,
+        "elapsed_sec": round(time.time() - started, 2),
+    }
+    return {
+        "root": root, "files": files, "import_edges": import_edges,
+        "symbols": symbols, "call_edges": call_edges, "externals": externals,
+        "external_users": external_users, "unresolved": unresolved,
+        "cycles": cycles, "entries": entries, "stats": stats,
+        "in_map": in_map, "out_map": out_map,
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Graph assembly (schema-stable output)
+# --------------------------------------------------------------------------------------
+
+def build_graph(scanned: dict):
+    root = scanned["root"]
+    files = scanned["files"]
+    nodes = []
+    edges = []
+
+    # module (directory) nodes
+    dir_stats = defaultdict(lambda: {"files": 0, "loc": 0, "layers": Counter(), "langs": Counter()})
+    for rel, info in files.items():
+        d = os.path.dirname(rel) or "."
+        st = dir_stats[d]
+        st["files"] += 1
+        st["loc"] += info["loc"]
+        st["layers"][info["layer"]] += 1
+        st["langs"][info["lang"]] += 1
+
+    # Materialise EVERY ancestor directory, not just the ones holding files, so the
+    # viewer can walk a real tree instead of a flat list. Without the intermediate
+    # levels "src/" would not exist when only "src/api/core/" holds code.
+    all_dirs = set(dir_stats)
+    for d in list(dir_stats):
+        if d == ".":
+            continue
+        parts = d.split("/")
+        for i in range(1, len(parts)):
+            all_dirs.add("/".join(parts[:i]))
+    all_dirs.add(".")
+
+    # Roll file counts/LOC up the tree so a collapsed parent reports its subtree.
+    roll = {d: {"files": 0, "loc": 0, "layers": Counter(), "langs": Counter()}
+            for d in all_dirs}
+    for d, st in dir_stats.items():
+        chain = ["."] if d == "." else \
+            ["."] + ["/".join(d.split("/")[:i + 1]) for i in range(len(d.split("/")))]
+        for anc in chain:
+            if anc not in roll:
+                continue
+            roll[anc]["files"] += st["files"]
+            roll[anc]["loc"] += st["loc"]
+            roll[anc]["layers"].update(st["layers"])
+            roll[anc]["langs"].update(st["langs"])
+
+    def parent_of(d):
+        if d == ".":
+            return None
+        return "/".join(d.split("/")[:-1]) or "."
+
+    for d in sorted(all_dirs):
+        st = roll[d]
+        own = dir_stats.get(d)
+        par = parent_of(d)
+        nodes.append({
+            "id": "mod:" + d,
+            "type": "module",
+            "name": (d.split("/")[-1] if d != "." else "(root)"),
+            "filePath": d,
+            "parent": ("mod:" + par) if par else None,
+            "depth": 0 if d == "." else d.count("/") + 1,
+            "layer": (st["layers"].most_common(1)[0][0] if st["layers"] else "other"),
+            "loc": st["loc"],                       # subtree total
+            "fileCount": st["files"],               # subtree total
+            "ownFiles": own["files"] if own else 0,  # files directly inside
+            "languages": [l for l, _ in st["langs"].most_common(4)],
+            "summary": "",
+            "tags": [],
+        })
+        # Directory -> subdirectory containment, so the tree is walkable.
+        if par:
+            edges.append({"source": "mod:" + par, "target": "mod:" + d,
+                          "type": "contains", "weight": 1.0})
+
+    for rel, info in sorted(files.items()):
+        node_type = {"code": "file", "config": "config", "document": "document",
+                     "infra": "config"}.get(info["kind"], "file")
+        nodes.append({
+            "id": "file:" + rel,
+            "type": node_type,
+            "name": os.path.basename(rel),
+            "filePath": rel,
+            "module": "mod:" + (os.path.dirname(rel) or "."),
+            "language": info["lang"],
+            "layer": info["layer"],
+            "loc": info["loc"],
+            "fanIn": info["fan_in"],
+            "fanOut": info["fan_out"],
+            "importance": info["importance"],
+            "isEntry": rel in scanned["entries"],
+            "defCount": len(info["defs"]),
+            "routes": info["extras"].get("routes", [])[:8],
+            "httpVerbs": info["extras"].get("http_verbs", []),
+            "title": info["extras"].get("title", ""),
+            # summary is pre-filled from the source's own docstring; the agent's
+            # enrich.json overrides it where it can say something better.
+            "doc": info.get("doc", ""),
+            "symbols": [d["name"] for d in info["defs"][:14]],
+            "summary": "",
+            "tags": [],
+        })
+        edges.append({"source": "mod:" + (os.path.dirname(rel) or "."),
+                      "target": "file:" + rel, "type": "contains", "weight": 1.0})
+
+    for sid, s in sorted(scanned["symbols"].items()):
+        nodes.append({
+            "id": sid,
+            "type": {"class": "class", "impl": "class", "type": "class", "schema": "schema",
+                     "table": "table", "service": "service", "resource": "resource"}
+                    .get(s["kind"], "function"),
+            "name": s["name"],
+            "filePath": s["file"],
+            "module": "mod:" + (os.path.dirname(s["file"]) or "."),
+            "lineRange": [s["line"], s["end_line"]],
+            "kind": s["kind"],
+            "loc": s["size"],
+            "layer": files[s["file"]]["layer"],
+            "summary": "",
+            "tags": [],
+        })
+        edges.append({"source": "file:" + s["file"], "target": sid,
+                      "type": "contains", "weight": 1.0})
+        if s.get("base"):
+            edges.append({"source": sid, "target": "ref:" + s["base"],
+                          "type": "inherits", "weight": 0.6, "unresolved": True})
+
+    for s, d in scanned["import_edges"]:
+        edges.append({"source": "file:" + s, "target": "file:" + d,
+                      "type": "imports", "weight": 1.0})
+
+    for src, dst, line in scanned["call_edges"]:
+        edges.append({
+            "source": src if src.startswith("sym:") else "file:" + src,
+            "target": dst, "type": "calls", "weight": 0.5, "line": line,
+        })
+
+    # external dependency nodes (capped: only ones actually used more than once or by many files)
+    ext_items = sorted(scanned["externals"].items(), key=lambda kv: -kv[1])[:60]
+    for name, count in ext_items:
+        nodes.append({
+            "id": "ext:" + name, "type": "external", "name": name, "layer": "external",
+            "usedBy": len(scanned["external_users"][name]), "importCount": count,
+            "summary": "", "tags": [],
+        })
+        for user in sorted(scanned["external_users"][name])[:40]:
+            edges.append({"source": "file:" + user, "target": "ext:" + name,
+                          "type": "depends_on", "weight": 0.3})
+
+    # Drop edges pointing at unresolved inheritance refs that never became nodes.
+    node_ids = {n["id"] for n in nodes}
+    edges = [e for e in edges if e["source"] in node_ids and e["target"] in node_ids]
+
+    lang_counter = Counter()
+    for info in files.values():
+        if info["kind"] == "code":
+            lang_counter[info["lang"]] += 1
+
+    layers = []
+    for lid in LAYER_ORDER:
+        member_ids = [n["id"] for n in nodes if n.get("layer") == lid]
+        if member_ids:
+            layers.append({"id": lid, "name": LAYER_LABELS.get(lid, lid.title()),
+                           "description": "", "nodeIds": member_ids})
+
+    graph = {
+        "version": SCHEMA_VERSION,
+        "kind": "codebase",
+        "project": {
+            "name": os.path.basename(root) or root,
+            "root": root,
+            "languages": [l for l, _ in lang_counter.most_common()],
+            "frameworks": detect_frameworks(root, list(files.keys())),
+            "description": "",
+            "analyzedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "gitCommitHash": git_commit(root),
+            "totalLoc": sum(i["loc"] for i in files.values()),
+        },
+        "stats": scanned["stats"],
+        "nodes": nodes,
+        "edges": edges,
+        "layers": layers,
+        "cycles": [["file:" + r for r in comp] for comp in scanned["cycles"]],
+        "tour": [],
+    }
+    return graph
+
+
+# --------------------------------------------------------------------------------------
+# Digest (what the agent actually reads)
+# --------------------------------------------------------------------------------------
+
+def build_digest(scanned: dict, graph: dict, top_n: int = 45) -> str:
+    files = scanned["files"]
+    p = graph["project"]
+    L = []
+    A = L.append
+
+    A("# codegraph digest: %s" % p["name"])
+    A("")
+    A("> Stage-1 deterministic scan. Read this instead of graph.json, then write enrich.json.")
+    A("")
+    A("- **Root**: `%s`" % p["root"])
+    A("- **Commit**: `%s`" % (p["gitCommitHash"] or "n/a"))
+    A("- **Indexed**: %d files, %s LOC (discovery: %s%s)" % (
+        scanned["stats"]["files_indexed"], f"{p['totalLoc']:,}",
+        scanned["stats"]["discovery"],
+        ", TRUNCATED — raise --max-files" if scanned["stats"]["truncated"] else ""))
+    A("- **Languages**: %s" % (", ".join(
+        "%s (%d)" % (l, sum(1 for i in files.values() if i["lang"] == l))
+        for l in p["languages"][:8]) or "n/a"))
+    A("- **Frameworks detected**: %s" % (", ".join(p["frameworks"][:12]) or "none detected"))
+    A("- **Graph**: %d nodes, %d edges" % (len(graph["nodes"]), len(graph["edges"])))
+    A("")
+
+    A("## Entry points (start reading here)")
+    if scanned["entries"]:
+        for rel in scanned["entries"][:12]:
+            i = files[rel]
+            extra = []
+            if i["extras"].get("routes"):
+                extra.append("routes: " + ", ".join(i["extras"]["routes"][:5]))
+            if i["extras"].get("http_verbs"):
+                extra.append("http: " + ",".join(i["extras"]["http_verbs"]))
+            A("- `%s` (%s, %d LOC, fan-in %d)%s" % (
+                rel, i["lang"], i["loc"], i["fan_in"],
+                " — " + "; ".join(extra) if extra else ""))
+    else:
+        A("- none detected by heuristics")
+    A("")
+
+    A("## Directory map (files / LOC / dominant layer)")
+    dirs = defaultdict(lambda: [0, 0, Counter()])
+    for rel, i in files.items():
+        d = os.path.dirname(rel) or "."
+        dirs[d][0] += 1
+        dirs[d][1] += i["loc"]
+        dirs[d][2][i["layer"]] += 1
+    shown = sorted(dirs.items(), key=lambda kv: -kv[1][1])[:40]
+    for d, (nf, loc, layers) in sorted(shown):
+        A("- `%s/` — %d files, %d LOC, mostly **%s**" % (
+            d, nf, loc, layers.most_common(1)[0][0]))
+    if len(dirs) > 40:
+        A("- ... %d more directories" % (len(dirs) - 40))
+    A("")
+
+    A("## Most important files (PageRank on imports + fan-in + size)")
+    A("")
+    A("| node id | LOC | in | out | layer | defs |")
+    A("|---|---|---|---|---|---|")
+    ranked = sorted(files.values(), key=lambda i: -i["importance"])[:top_n]
+    for i in ranked:
+        A("| `file:%s` | %d | %d | %d | %s | %s |" % (
+            i["rel"], i["loc"], i["fan_in"], i["fan_out"], i["layer"],
+            ", ".join(d["name"] for d in i["defs"][:5]) or "—"))
+    A("")
+
+    if scanned["cycles"]:
+        A("## Dependency cycles (refactor candidates)")
+        for comp in scanned["cycles"][:8]:
+            A("- %d files: %s" % (len(comp), ", ".join("`%s`" % c for c in comp[:6]) +
+                                  (" ..." if len(comp) > 6 else "")))
+        A("")
+
+    A("## Top external dependencies")
+    top_ext = sorted(scanned["externals"].items(), key=lambda kv: -kv[1])[:25]
+    A(", ".join("`%s` (%d)" % (n, c) for n, c in top_ext) or "none")
+    A("")
+
+    A("## Heuristic layer assignment (override in enrich.json when wrong)")
+    layer_counts = Counter(i["layer"] for i in files.values())
+    for lid in LAYER_ORDER:
+        if layer_counts.get(lid):
+            A("- **%s** (`%s`): %d files" % (LAYER_LABELS.get(lid, lid), lid, layer_counts[lid]))
+    A("")
+
+    A("## Your job (stage 2)")
+    A("")
+    A("Write `enrich.json` next to this digest:")
+    A("")
+    A("```json")
+    A("{")
+    A('  "project": { "description": "1-3 sentences: what this codebase IS and does" },')
+    A('  "nodes": {')
+    A('    "file:path/to/file.ts": { "summary": "plain-English what+why, 1-2 sentences",')
+    A('                              "layer": "service", "tags": ["auth"] }')
+    A("  },")
+    A('  "layers": { "service": "what this layer means in THIS project" },')
+    A('  "tours": [')
+    A('    { "title": "Request lifecycle", "description": "why this tour matters",')
+    A('      "steps": [ { "nodeId": "file:src/index.ts", "note": "why this step matters" } ] }')
+    A("  ]")
+    A("}")
+    A("```")
+    A("")
+    A("Rules: only use node ids that exist above; summarize the top files first; "
+      "1 tour minimum, 3-6 steps each; never invent files.")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="scan.py", description="Deterministic codebase -> structural graph (codegraph stage 1)")
+    ap.add_argument("root", nargs="?", default=".", help="repository root (default: .)")
+    ap.add_argument("-o", "--out", default=".codegraph", help="output directory (default: .codegraph)")
+    ap.add_argument("--max-files", type=int, default=4000, help="cap indexed files (default: 4000)")
+    ap.add_argument("--symbols-for", type=int, default=250,
+                    help="extract symbol nodes for the N most important files (default: 250)")
+    ap.add_argument("--no-calls", action="store_true", help="skip heuristic cross-file call edges")
+    ap.add_argument("--digest-top", type=int, default=45, help="rows in the digest importance table")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not os.path.isdir(args.root):
+        print("error: not a directory: %s" % args.root, file=sys.stderr)
+        return 2
+
+    scanned = scan(args.root, args.max_files, not args.no_calls, args.symbols_for)
+    if not scanned["files"]:
+        print("error: no source files found under %s" % args.root, file=sys.stderr)
+        return 1
+
+    graph = build_graph(scanned)
+    digest = build_digest(scanned, graph, args.digest_top)
+
+    outdir = args.out if os.path.isabs(args.out) else os.path.join(os.path.abspath(args.root), args.out)
+    os.makedirs(outdir, exist_ok=True)
+    gpath = os.path.join(outdir, "graph.json")
+    dpath = os.path.join(outdir, "digest.md")
+    with open(gpath, "w", encoding="utf-8") as fh:
+        json.dump(graph, fh, indent=1, sort_keys=False)
+    with open(dpath, "w", encoding="utf-8") as fh:
+        fh.write(digest + "\n")
+
+    if not args.quiet:
+        s = scanned["stats"]
+        print("codegraph scan complete in %ss" % s["elapsed_sec"])
+        print("  indexed   : %d files (%s LOC)" % (s["files_indexed"], f"{graph['project']['totalLoc']:,}"))
+        print("  graph     : %d nodes, %d edges" % (len(graph["nodes"]), len(graph["edges"])))
+        print("  cycles    : %d" % len(graph["cycles"]))
+        print("  languages : %s" % ", ".join(graph["project"]["languages"][:6]))
+        print("  graph.json: %s" % gpath)
+        print("  digest.md : %s   <- read this next" % dpath)
+        if s["truncated"]:
+            print("  WARNING: file cap hit; rerun with --max-files %d" % (args.max_files * 3))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/codegraph/scripts/test_codegraph.py
+++ b/skills/codegraph/scripts/test_codegraph.py
@@ -1,0 +1,920 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the codegraph pipeline. Stdlib only (unittest).
+
+Run:
+    python3 test_codegraph.py           # quiet
+    python3 test_codegraph.py -v        # verbose
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import scan      # noqa: E402
+import render    # noqa: E402
+import overview  # noqa: E402
+
+
+# --------------------------------------------------------------------------------------
+# Fixture: a tiny polyglot repo with known structure, one cycle, and a clear entry point.
+# --------------------------------------------------------------------------------------
+
+FIXTURE = {
+    "src/main.py": (
+        "import os\n"
+        "from src.services.auth import login\n"
+        "from src.models.user import User\n"
+        "import requests\n"
+        "\n"
+        "def main():\n"
+        "    u = User('a')\n"
+        "    return login(u)\n"
+    ),
+    "src/services/auth.py": (
+        '"""Authentication service: verifies credentials and issues sessions."""\n'
+        "from src.models.user import User\n"
+        "from src.utils.hashing import hash_password\n"
+        "\n"
+        "def login(user):\n"
+        "    return hash_password(user.name)\n"
+        "\n"
+        "class AuthService:\n"
+        "    def authenticate(self):\n"
+        "        return True\n"
+    ),
+    "src/models/user.py": (
+        "from src.utils.hashing import hash_password\n"
+        "\n"
+        "class User:\n"
+        "    def __init__(self, name):\n"
+        "        self.name = name\n"
+    ),
+    "src/utils/hashing.py": (
+        '"""Password hashing helpers shared by every auth path."""\n'
+        "import hashlib\n"
+        "\n"
+        "def hash_password(pw):\n"
+        "    return hashlib.sha256(pw.encode()).hexdigest()\n"
+    ),
+    # Deliberate 2-file import cycle for SCC detection.
+    "src/cycle_a.py": "from src.cycle_b import beta\n\ndef alpha():\n    return beta()\n",
+    "src/cycle_b.py": "from src.cycle_a import alpha\n\ndef beta():\n    return 1\n",
+    "web/app.ts": (
+        "import { helper } from './helper';\n"
+        "import express from 'express';\n"
+        "\n"
+        "export const router = express.Router();\n"
+        "router.get('/users', (req, res) => res.json(helper()));\n"
+        "\n"
+        "export class Controller {\n"
+        "  handle() { return helper(); }\n"
+        "}\n"
+    ),
+    "web/helper.ts": ("/**\n * Returns the canonical answer.\n */\n"
+                      "export function helper() {\n  return 42;\n}\n"),
+    "cmd/server/main.go": (
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\t"fmt"\n'
+        '\t"github.com/example/proj/internal/store"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        "\tfmt.Println(store.Get())\n"
+        "}\n"
+    ),
+    "internal/store/store.go": (
+        "package store\n"
+        "\n"
+        "type Store struct{ n int }\n"
+        "\n"
+        "func Get() int { return 1 }\n"
+    ),
+    "go.mod": "module github.com/example/proj\n\ngo 1.21\n",
+    "package.json": '{"name":"fx","dependencies":{"express":"^4.0.0","react":"^18.0.0"}}\n',
+    "requirements.txt": "requests==2.31.0\nflask\n",
+    "README.md": "# Fixture Project\n\nA test fixture.\n",
+    "tests/test_auth.py": "from src.services.auth import login\n\ndef test_login():\n    assert True\n",
+    "node_modules/junk/index.js": "module.exports = 'should be ignored';\n",
+    "dist/bundle.min.js": "var a=1;" * 50 + "\n",
+}
+
+
+def make_repo(root):
+    for rel, content in FIXTURE.items():
+        path = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+
+
+class Base(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp(prefix="codegraph-test-")
+        cls.repo = os.path.join(cls.tmp, "repo")
+        os.makedirs(cls.repo)
+        make_repo(cls.repo)
+        cls.scanned = scan.scan(cls.repo, max_files=4000, want_calls=True, symbols_for=250)
+        cls.graph = scan.build_graph(cls.scanned)
+        cls.ids = {n["id"] for n in cls.graph["nodes"]}
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+
+class TestDiscovery(Base):
+    def test_finds_source_files(self):
+        self.assertIn("file:src/main.py", self.ids)
+        self.assertIn("file:web/app.ts", self.ids)
+        self.assertIn("file:cmd/server/main.go", self.ids)
+
+    def test_excludes_node_modules_and_minified(self):
+        rels = set(self.scanned["files"])
+        self.assertNotIn("node_modules/junk/index.js", rels)
+        self.assertNotIn("dist/bundle.min.js", rels)
+
+    def test_keeps_docs_and_config_as_context(self):
+        self.assertIn("file:README.md", self.ids)
+        self.assertIn("file:package.json", self.ids)
+
+    def test_language_detection(self):
+        langs = self.graph["project"]["languages"]
+        for expected in ("python", "typescript", "go"):
+            self.assertIn(expected, langs)
+
+    def test_framework_detection(self):
+        fw = self.graph["project"]["frameworks"]
+        self.assertIn("Express", fw)
+        self.assertIn("React", fw)
+        self.assertIn("Flask", fw)
+
+
+class TestImportResolution(Base):
+    def _has_import(self, src, dst):
+        return any(e["type"] == "imports" and e["source"] == "file:" + src
+                   and e["target"] == "file:" + dst for e in self.graph["edges"])
+
+    def test_python_package_import(self):
+        self.assertTrue(self._has_import("src/main.py", "src/services/auth.py"))
+        self.assertTrue(self._has_import("src/main.py", "src/models/user.py"))
+
+    def test_python_shared_dependency(self):
+        self.assertTrue(self._has_import("src/services/auth.py", "src/utils/hashing.py"))
+        self.assertTrue(self._has_import("src/models/user.py", "src/utils/hashing.py"))
+
+    def test_typescript_relative_import(self):
+        self.assertTrue(self._has_import("web/app.ts", "web/helper.ts"))
+
+    def test_go_module_import(self):
+        self.assertTrue(self._has_import("cmd/server/main.go", "internal/store/store.go"))
+
+    def test_externals_recorded_not_as_files(self):
+        self.assertIn("ext:requests", self.ids)
+        self.assertIn("ext:express", self.ids)
+        # stdlib/3rd-party must never become file nodes
+        self.assertNotIn("file:requests", self.ids)
+
+    def test_no_self_imports(self):
+        for e in self.graph["edges"]:
+            self.assertNotEqual(e["source"], e["target"])
+
+
+class TestSymbols(Base):
+    def test_extracts_python_symbols(self):
+        names = {n["name"] for n in self.graph["nodes"] if n["id"].startswith("sym:")}
+        for expected in ("login", "AuthService", "User", "hash_password", "main"):
+            self.assertIn(expected, names)
+
+    def test_extracts_typescript_symbols(self):
+        names = {n["name"] for n in self.graph["nodes"] if n["id"].startswith("sym:")}
+        self.assertIn("helper", names)
+        self.assertIn("Controller", names)
+
+    def test_extracts_go_symbols(self):
+        names = {n["name"] for n in self.graph["nodes"] if n["id"].startswith("sym:")}
+        self.assertIn("Store", names)
+
+    def test_symbols_have_valid_line_ranges(self):
+        for n in self.graph["nodes"]:
+            if not n["id"].startswith("sym:"):
+                continue
+            lo, hi = n["lineRange"]
+            self.assertGreaterEqual(lo, 1)
+            self.assertGreaterEqual(hi, lo)
+
+    def test_symbols_are_contained_by_their_file(self):
+        contains = {(e["source"], e["target"]) for e in self.graph["edges"]
+                    if e["type"] == "contains"}
+        for n in self.graph["nodes"]:
+            if n["id"].startswith("sym:"):
+                self.assertIn(("file:" + n["filePath"], n["id"]), contains)
+
+
+class TestMetrics(Base):
+    def test_detects_import_cycle(self):
+        flat = {nid for comp in self.graph["cycles"] for nid in comp}
+        self.assertIn("file:src/cycle_a.py", flat)
+        self.assertIn("file:src/cycle_b.py", flat)
+
+    def test_shared_utility_has_highest_fan_in(self):
+        hashing = next(n for n in self.graph["nodes"] if n["id"] == "file:src/utils/hashing.py")
+        self.assertGreaterEqual(hashing["fanIn"], 2)
+
+    def test_entry_point_detection(self):
+        entries = {n["id"] for n in self.graph["nodes"] if n.get("isEntry")}
+        self.assertTrue(
+            {"file:src/main.py", "file:cmd/server/main.go"} & entries,
+            "expected at least one main.* to be flagged as an entry point")
+
+    def test_route_extraction_only_from_real_declarations(self):
+        app = next(n for n in self.graph["nodes"] if n["id"] == "file:web/app.ts")
+        self.assertIn("/users", app.get("routes", []))
+
+    def test_importance_is_bounded(self):
+        for n in self.graph["nodes"]:
+            if "importance" in n:
+                self.assertGreaterEqual(n["importance"], 0.0)
+                self.assertLessEqual(n["importance"], 1.0)
+
+    def test_layers_assigned(self):
+        layer_ids = {l["id"] for l in self.graph["layers"]}
+        self.assertIn("test", layer_ids)
+        by_id = {n["id"]: n for n in self.graph["nodes"]}
+        self.assertEqual(by_id["file:tests/test_auth.py"]["layer"], "test")
+
+    def test_determinism(self):
+        again = scan.build_graph(
+            scan.scan(self.repo, max_files=4000, want_calls=True, symbols_for=250))
+        self.assertEqual(
+            json.dumps(self.graph["nodes"], sort_keys=True),
+            json.dumps(again["nodes"], sort_keys=True))
+        self.assertEqual(len(self.graph["edges"]), len(again["edges"]))
+
+
+class TestGraphIntegrity(Base):
+    def test_no_dangling_edges(self):
+        for e in self.graph["edges"]:
+            self.assertIn(e["source"], self.ids)
+            self.assertIn(e["target"], self.ids)
+
+    def test_unique_node_ids(self):
+        all_ids = [n["id"] for n in self.graph["nodes"]]
+        self.assertEqual(len(all_ids), len(set(all_ids)))
+
+    def test_passes_renderer_validation(self):
+        errors, _ = render.validate_graph(self.graph)
+        self.assertEqual(errors, [])
+
+    def test_digest_mentions_key_facts(self):
+        digest = scan.build_digest(self.scanned, self.graph)
+        self.assertIn("Entry points", digest)
+        self.assertIn("hashing.py", digest)
+        self.assertIn("enrich.json", digest)
+        self.assertIn("Dependency cycles", digest)
+
+
+class TestValidation(unittest.TestCase):
+    def test_rejects_missing_keys(self):
+        errors, _ = render.validate_graph({"nodes": [], "edges": []})
+        self.assertTrue(any("version" in e for e in errors))
+
+    def test_rejects_dangling_edge(self):
+        bad = {"version": "1", "project": {"name": "x"},
+               "nodes": [{"id": "a", "name": "A"}],
+               "edges": [{"source": "a", "target": "ghost", "type": "imports"}]}
+        errors, _ = render.validate_graph(bad)
+        self.assertTrue(any("unknown node ids" in e for e in errors))
+
+    def test_rejects_duplicate_ids(self):
+        bad = {"version": "1", "project": {"name": "x"},
+               "nodes": [{"id": "a", "name": "A"}, {"id": "a", "name": "A2"}],
+               "edges": []}
+        errors, _ = render.validate_graph(bad)
+        self.assertTrue(any("duplicate" in e for e in errors))
+
+    def test_rejects_empty_nodes(self):
+        bad = {"version": "1", "project": {"name": "x"}, "nodes": [], "edges": []}
+        errors, _ = render.validate_graph(bad)
+        self.assertTrue(errors)
+
+
+class TestEnrichment(Base):
+    def test_valid_enrichment_merges(self):
+        enrich = {
+            "project": {"description": "A fixture."},
+            "nodes": {"file:src/main.py": {"summary": "Entry point.", "layer": "entry",
+                                          "tags": ["boot"]}},
+            "layers": {"entry": "Process entry points."},
+            "tours": [{"title": "T", "steps": [{"nodeId": "file:src/main.py", "note": "start"}]}],
+        }
+        clean, warns = render.validate_enrich(enrich, self.ids)
+        merged = render.merge(json.loads(json.dumps(self.graph)), clean)
+        node = next(n for n in merged["nodes"] if n["id"] == "file:src/main.py")
+        self.assertEqual(node["summary"], "Entry point.")
+        self.assertEqual(node["tags"], ["boot"])
+        self.assertEqual(merged["project"]["description"], "A fixture.")
+        self.assertEqual(len(merged["tour"]), 1)
+        self.assertEqual(merged["enrichedNodes"], 1)
+
+    def test_unknown_node_ids_are_dropped_not_fatal(self):
+        clean, warns = render.validate_enrich(
+            {"nodes": {"file:does/not/exist.py": {"summary": "ghost"}}}, self.ids)
+        self.assertEqual(clean["nodes"], {})
+        self.assertTrue(any("unknown node ids" in w for w in warns))
+
+    def test_tour_with_no_valid_steps_is_dropped(self):
+        clean, warns = render.validate_enrich(
+            {"tours": [{"title": "Ghost", "steps": [{"nodeId": "file:nope.py"}]}]}, self.ids)
+        self.assertEqual(clean["tours"], [])
+        self.assertTrue(any("Ghost" in w for w in warns))
+
+    def test_string_shorthand_summary(self):
+        clean, _ = render.validate_enrich(
+            {"nodes": {"file:src/main.py": "just a string"}}, self.ids)
+        self.assertEqual(clean["nodes"]["file:src/main.py"]["summary"], "just a string")
+
+    def test_layer_override_applies(self):
+        clean, _ = render.validate_enrich(
+            {"nodes": {"file:src/utils/hashing.py": {"summary": "s", "layer": "data"}}}, self.ids)
+        merged = render.merge(json.loads(json.dumps(self.graph)), clean)
+        node = next(n for n in merged["nodes"] if n["id"] == "file:src/utils/hashing.py")
+        self.assertEqual(node["layer"], "data")
+
+    def test_garbage_enrichment_is_ignored(self):
+        clean, warns = render.validate_enrich(["not", "a", "dict"], self.ids)
+        self.assertEqual(clean, {})
+        self.assertTrue(warns)
+
+
+class TestOverview(Base):
+    """The overview must summarize the real graph and never invent structure."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ov = overview.build(cls.graph)
+
+    def test_builds_from_graph(self):
+        self.assertIsNotNone(self.ov)
+        self.assertTrue(self.ov["boxes"], "expected at least one module box")
+        self.assertGreater(self.ov["width"], 0)
+        self.assertGreater(self.ov["height"], 0)
+
+    def test_boxes_are_real_modules(self):
+        mod_ids = {n["id"] for n in self.graph["nodes"] if n["id"].startswith("mod:")}
+        for b in self.ov["boxes"]:
+            self.assertIn(b["id"], mod_ids, "overview invented module %r" % b["id"])
+
+    def test_edges_reference_visible_boxes_only(self):
+        ids = {b["id"] for b in self.ov["boxes"]}
+        for e in self.ov["edges"]:
+            self.assertIn(e["from"], ids)
+            self.assertIn(e["to"], ids)
+            self.assertNotEqual(e["from"], e["to"], "self-loop in overview")
+
+    def test_every_edge_has_a_path(self):
+        for e in self.ov["edges"]:
+            self.assertTrue(e["d"].startswith("M"), "edge without geometry: %r" % e)
+
+    def test_journey_hops_are_real_edges(self):
+        pairs = {(e["from"], e["to"]) for e in self.ov["edges"]}
+        for a, b in self.ov["journey"]:
+            self.assertIn((a, b), pairs, "journey hop %s->%s is not an edge" % (a, b))
+
+    def test_journey_is_contiguous(self):
+        hops = self.ov["journey"]
+        for i in range(len(hops) - 1):
+            self.assertEqual(hops[i][1], hops[i + 1][0], "journey is not a single path")
+
+    def test_boxes_do_not_overlap(self):
+        """Geometry contract: no two boxes may intersect (glowmotion's C1 rule)."""
+        bs = self.ov["boxes"]
+        for i in range(len(bs)):
+            for j in range(i + 1, len(bs)):
+                a, b = bs[i], bs[j]
+                overlap = (a["x"] < b["x"] + b["w"] and a["x"] + a["w"] > b["x"] and
+                           a["y"] < b["y"] + b["h"] and a["y"] + a["h"] > b["y"])
+                self.assertFalse(overlap, "%s overlaps %s" % (a["label"], b["label"]))
+
+    def test_boxes_inside_canvas(self):
+        for b in self.ov["boxes"]:
+            self.assertGreaterEqual(b["x"], 0)
+            self.assertGreaterEqual(b["y"], 0)
+            self.assertLessEqual(b["x"] + b["w"], self.ov["width"])
+            self.assertLessEqual(b["y"] + b["h"], self.ov["height"])
+
+    def test_rows_cover_every_box(self):
+        rows = {r["row"] for r in self.ov["rows"]}
+        for b in self.ov["boxes"]:
+            self.assertIn(b["row"], rows)
+
+    def test_landscape_aspect(self):
+        """A tall thin column is unreadable; the overview must stay wide-ish."""
+        self.assertGreater(self.ov["width"] / self.ov["height"], 0.6)
+
+    def test_deterministic(self):
+        again = overview.build(self.graph)
+        self.assertEqual(json.dumps(self.ov, sort_keys=True),
+                         json.dumps(again, sort_keys=True))
+
+    def test_config_only_module_is_omitted(self):
+        """A directory of pure config (no source) is scaffolding, not architecture."""
+        labels = {b["path"] for b in self.ov["boxes"]}
+        # The fixture's repo root holds only package.json/requirements/README.
+        self.assertNotIn(".", labels)
+
+    def test_embedded_in_rendered_html(self):
+        html = render.render_html(self.graph, "fixture")
+        self.assertIn('"overview"', html)
+        self.assertIn("buildOverview", html)
+
+    def test_survives_graph_without_files(self):
+        empty = {"version": "1", "project": {"name": "x"}, "nodes": [], "edges": []}
+        self.assertIsNone(overview.build(empty))
+
+
+class TestDocExtraction(Base):
+    """A node with only numbers teaches nothing. The code already documents
+    itself in ~90% of real repos, so read that instead of asking a model."""
+
+    def test_extracts_python_module_docstring(self):
+        q = chr(34) * 3
+        doc = scan.extract_doc("python", q + "Thread-safe singleton state." + q + "\nimport os\n")
+        self.assertEqual(doc, "Thread-safe singleton state.")
+
+    def test_falls_back_to_first_definition(self):
+        q = chr(34) * 3
+        src = "import os\n\n\nclass Thing:\n    " + q + "Owns the widget lifecycle." + q + "\n"
+        self.assertIn("widget lifecycle", scan.extract_doc("python", src))
+
+    def test_stops_at_structured_sections(self):
+        q = chr(34) * 3
+        src = q + "Do the thing.\n\nArgs:\n    x: ignored\n" + q + "\n"
+        doc = scan.extract_doc("python", src)
+        self.assertEqual(doc, "Do the thing.")
+        self.assertNotIn("ignored", doc)
+
+    def test_skips_boilerplate_headers(self):
+        for noise in ("#!/usr/bin/env python\n# -*- coding: utf-8 -*-\n",
+                      "// Copyright 2024 Someone\n// SPDX-License-Identifier: MIT\n"):
+            lang = "python" if noise.startswith("#!") else "typescript"
+            self.assertEqual(scan.extract_doc(lang, noise), "",
+                             "boilerplate leaked into a summary: %r" % noise)
+
+    def test_extracts_jsdoc_block(self):
+        src = "/**\n * Streams query results over SSE.\n */\nexport function run() {}\n"
+        self.assertIn("Streams query results", scan.extract_doc("typescript", src))
+
+    def test_extracts_go_line_comments(self):
+        src = "// Package store persists orders.\npackage store\n"
+        self.assertIn("persists orders", scan.extract_doc("go", src))
+
+    def test_summary_is_bounded(self):
+        q = chr(34) * 3
+        long = q + ("word " * 400) + q + "\n"
+        self.assertLessEqual(len(scan.extract_doc("python", long)), 260)
+
+    def test_docs_land_on_nodes(self):
+        docs = [n for n in self.graph["nodes"] if n.get("doc")]
+        self.assertTrue(docs, "no docstring reached any node")
+        syms = [n for n in self.graph["nodes"] if n.get("symbols")]
+        self.assertTrue(syms, "no symbol list reached any node")
+
+    def test_docstring_fills_summary_but_agent_wins(self):
+        graph = json.loads(json.dumps(self.graph))
+        target = next(n for n in graph["nodes"] if n.get("doc"))
+        merged = render.merge(graph, {})
+        node = next(n for n in merged["nodes"] if n["id"] == target["id"])
+        self.assertEqual(node["summary"], target["doc"])
+        self.assertEqual(node["summarySource"], "docstring")
+        # An agent summary must override the extracted one.
+        graph2 = json.loads(json.dumps(self.graph))
+        clean, _ = render.validate_enrich(
+            {"nodes": {target["id"]: {"summary": "Agent knows better."}}},
+            {n["id"] for n in graph2["nodes"]})
+        merged2 = render.merge(graph2, clean)
+        node2 = next(n for n in merged2["nodes"] if n["id"] == target["id"])
+        self.assertEqual(node2["summary"], "Agent knows better.")
+        self.assertEqual(node2["summarySource"], "agent")
+
+
+class TestStarMap(Base):
+    """The star map reads the same graph as mass instead of layers."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sm = overview.build(cls.graph)["starmap"]
+
+    def test_present_and_populated(self):
+        self.assertTrue(self.sm["galaxies"])
+        self.assertTrue(self.sm["stars"])
+
+    def test_stars_inside_canvas(self):
+        for s in self.sm["stars"]:
+            self.assertGreaterEqual(s["x"], 0)
+            self.assertGreaterEqual(s["y"], 0)
+            self.assertLessEqual(s["x"], self.sm["width"])
+            self.assertLessEqual(s["y"], self.sm["height"])
+
+    def test_galaxies_do_not_collide(self):
+        gs = self.sm["galaxies"]
+        for i in range(len(gs)):
+            for j in range(i + 1, len(gs)):
+                a, b = gs[i], gs[j]
+                d = ((a["x"] - b["x"]) ** 2 + (a["y"] - b["y"]) ** 2) ** 0.5
+                self.assertGreater(d, (a["r"] + b["r"]) * 0.55,
+                                   "%s overlaps %s" % (a["label"], b["label"]))
+
+    def test_magnitudes_are_spread_not_saturated(self):
+        """A saturated field loses all ranking information."""
+        mags = [s["mag"] for s in self.sm["stars"]]
+        for m in mags:
+            self.assertGreaterEqual(m, 0.0)
+            self.assertLessEqual(m, 1.0)
+        sat = sum(1 for m in mags if m >= 0.999)
+        self.assertLess(sat, max(2, len(mags) * 0.25), "too many stars saturated")
+
+    def test_links_reference_real_galaxies(self):
+        ids = {g["id"] for g in self.sm["galaxies"]}
+        for l in self.sm["links"]:
+            self.assertIn(l["from"], ids)
+            self.assertIn(l["to"], ids)
+
+    def test_deterministic(self):
+        again = overview.build(self.graph)["starmap"]
+        self.assertEqual(json.dumps(self.sm, sort_keys=True),
+                         json.dumps(again, sort_keys=True))
+
+    def test_viewer_wires_the_view(self):
+        tpl = render.load_template()
+        for token in ('id="sky"', 'id="mStar"', "function drawSky", "paintStar",
+                      "function skyHit", "starmap"):
+            self.assertIn(token, tpl, "star map lost %r" % token)
+
+    def test_stars_have_depth(self):
+        """Without z there is nothing to rotate — the map would be a flat picture."""
+        for s in self.sm["stars"]:
+            self.assertIn("z", s)
+        for g in self.sm["galaxies"]:
+            self.assertIn("z", g)
+        zs = [s["z"] for s in self.sm["stars"]]
+        self.assertGreater(max(zs) - min(zs), 10, "disc has no thickness")
+
+    def test_orbit_camera_wired(self):
+        """Drag-to-rotate, wheel dolly, damping, pan and reset must all exist."""
+        tpl = render.load_template()
+        for token in ("function project", "function skyTick", "function skyReset",
+                      "SKY.yaw", "SKY.pitch", "SKY.zoomTo", "SKY.vYaw",
+                      "PITCH_MIN", "PITCH_MAX", "touchstart", "wheel"):
+            self.assertIn(token, tpl, "orbit camera lost %r" % token)
+
+    def test_projection_sorts_by_depth(self):
+        """Painting order must be far-to-near or nearer stars get buried."""
+        tpl = render.load_template()
+        self.assertIn("b.depth - a.depth", tpl)
+
+    def test_no_scale_field_shadowing(self):
+        """project() returns `s` (scale); spreading a star as `s` shadowed its id
+        and threw on every frame. Guard the fixed idiom."""
+        tpl = render.load_template()
+        self.assertNotIn("Object.assign({ s: s }, project", tpl)
+        self.assertIn("p.star = st", tpl)
+
+
+class TestViewerTemplate(Base):
+    def test_viewer_file_exists_and_is_complete(self):
+        self.assertTrue(os.path.isfile(render.VIEWER_PATH), "viewer.html is missing")
+        tpl = render.load_template()
+        self.assertIn("__DATA__", tpl)
+        self.assertIn("__TITLE__", tpl)
+        self.assertTrue(tpl.rstrip().endswith("</html>"))
+
+    def test_animation_layer_present(self):
+        """The motion layer is part of the contract; guard against regressions."""
+        tpl = render.load_template()
+        for token in ('id="fx"', "requestAnimationFrame(frame)", "buildPackets",
+                      "drawPackets", "drawHalos", "drawStars", "setMotion",
+                      "prefers-reduced-motion"):
+            self.assertIn(token, tpl, "animation layer lost %r" % token)
+
+    def test_motion_respects_reduced_preference(self):
+        tpl = render.load_template()
+        self.assertIn('matchMedia("(prefers-reduced-motion: reduce)")', tpl)
+        self.assertIn("setMotion(!REDUCED)", tpl)
+
+    def test_hierarchy_tree_is_complete(self):
+        """Progressive disclosure needs a real tree: every ancestor must exist."""
+        mods = {n["id"]: n for n in self.graph["nodes"] if n["type"] == "module"}
+        self.assertTrue(mods)
+        roots = [m for m in mods.values() if not m.get("parent")]
+        self.assertEqual(len(roots), 1, "expected exactly one tree root")
+        for m in mods.values():
+            if m.get("parent"):
+                self.assertIn(m["parent"], mods, "%s has a missing parent" % m["id"])
+
+    def test_module_stats_roll_up(self):
+        """A collapsed parent must report its whole subtree, or +N lies."""
+        mods = {n["id"]: n for n in self.graph["nodes"] if n["type"] == "module"}
+        root = next(m for m in mods.values() if not m.get("parent"))
+        files = [n for n in self.graph["nodes"]
+                 if n.get("type") in ("file", "config", "document")]
+        self.assertEqual(root["fileCount"], len(files),
+                         "root subtree count does not match the file total")
+        for m in mods.values():
+            kids = [c for c in mods.values() if c.get("parent") == m["id"]]
+            if kids:
+                self.assertGreaterEqual(
+                    m["fileCount"], max(k["fileCount"] for k in kids),
+                    "%s reports fewer files than a child" % m["id"])
+
+    def test_containment_edges_link_modules(self):
+        mods = {n["id"] for n in self.graph["nodes"] if n["type"] == "module"}
+        pairs = {(e["source"], e["target"]) for e in self.graph["edges"]
+                 if e["type"] == "contains"}
+        for n in self.graph["nodes"]:
+            if n["type"] == "module" and n.get("parent"):
+                self.assertIn((n["parent"], n["id"]), pairs,
+                              "no contains edge for %s" % n["id"])
+
+    def test_hierarchy_viewer_wired(self):
+        tpl = render.load_template()
+        for token in ("function layoutTree", "function toggleExpand",
+                      "function hiddenChildCount", "function openTo",
+                      "S.open", "S.openFiles", 'id="bHier"', "MOD_KIDS",
+                      "function openAtEntry", 'id="startHere"'):
+            self.assertIn(token, tpl, "hierarchy lost %r" % token)
+
+    def test_ask_context_wired(self):
+        """Offline artifact: no API key, so it hands you a prompt instead."""
+        tpl = render.load_template()
+        self.assertIn("function copyAskContext", tpl)
+        self.assertIn("data-ask", tpl)
+        # Must ship real facts, not just a file name.
+        for token in ("Depends on: ", "Used by: ", "Defines: ", "Question:"):
+            self.assertIn(token, tpl, "ask prompt missing %r" % token)
+        # And must never embed a key or call out to a model.
+        self.assertNotRegex(tpl, r"""api[_-]?key\s*[:=]\s*["'][A-Za-z0-9]""")
+
+    def test_declutter_controls_present(self):
+        """Dense graphs are unreadable by default, so the simplifiers must exist."""
+        tpl = render.load_template()
+        for token in ("foldHubs", "neighborhood", "isFoldedHub", "HUB_MIN",
+                      "HOOD_MAX", "computeDegrees", 'id="bFold"', 'id="bHood"'):
+            self.assertIn(token, tpl, "declutter control lost %r" % token)
+
+    def test_starts_simplified(self):
+        """Defaults must favour readability: tests hidden, hubs folded, calls off."""
+        tpl = render.load_template()
+        self.assertIn('hiddenLayers: new Set(["test"])', tpl)
+        self.assertRegex(tpl, r"foldHubs:\s*true")
+        self.assertRegex(tpl, r"calls:\s*false")
+
+    def test_folded_edges_are_recoverable(self):
+        """Nothing may vanish silently — a hub advertises and reveals its edges."""
+        tpl = render.load_template()
+        self.assertIn("S.expanded.add(n.id)", tpl)   # click to expand
+        self.assertIn('"⋯"', tpl)                    # badge showing the count
+
+    def test_floating_panels_stack_above_views(self):
+        """Regression: #ov (z-index 1) once covered the tour panel, eating its
+        Prev/Next/Close clicks. Every floating panel must outrank the views."""
+        tpl = render.load_template()
+        flat = tpl.replace(" ", "").replace("\n", "")
+
+        def z_of(pattern):
+            m = re.search(pattern + r"[^}]*?z-index:(\d+)", flat)
+            return int(m.group(1)) if m else None
+
+        panel_z = z_of(r"\.panel\{")
+        view_z = z_of(r"#ov\{")
+        tour_z = z_of(r"#tour\{")
+        self.assertIsNotNone(panel_z, ".panel has no explicit z-index")
+        self.assertIsNotNone(view_z, "#ov has no explicit z-index")
+        self.assertIsNotNone(tour_z, "#tour has no explicit z-index")
+        self.assertGreater(panel_z, view_z, "panels would sit under the overview")
+        self.assertGreaterEqual(tour_z, panel_z, "tour would sit under other panels")
+
+    def test_tour_forces_explore_mode(self):
+        """Tour steps address graph nodes, so it must not run over the overview."""
+        tpl = render.load_template()
+        self.assertRegex(tpl, r'if \(S\.mode !== "explore"\) setMode\("explore"\)')
+        # Leaving explore must close the tour rather than orphan the panel.
+        self.assertIn("if (S.tourIdx >= 0) closeTour();", tpl)
+        # A modal alert would block the page; the button must self-disable instead.
+        self.assertNotRegex(tpl, r"^\s*alert\(", "blocking alert() in the viewer")
+        self.assertIn('tb.disabled = true', tpl)
+
+    def test_select_follows_dark_theme(self):
+        """Native dropdown popups are OS-painted; color-scheme is what themes them."""
+        tpl = render.load_template()
+        flat = tpl.replace(" ", "").replace("\n", "")
+        self.assertIn("color-scheme:dark", flat)
+        self.assertIn('html[data-theme="light"]select{color-scheme:light}', flat)
+        self.assertIn("selectoption{", flat, "option colors missing for Windows/Linux")
+
+    def test_edge_labels_and_flow_present(self):
+        """Explore edges must be named and must visibly flow."""
+        tpl = render.load_template()
+        for token in ("drawEdgeLabels", "drawLiveEdges", "lineDashOffset",
+                      "liveEdgesFor", "LIVE_EDGE_CAP"):
+            self.assertIn(token, tpl, "edge animation lost %r" % token)
+        # Every relationship the scanner emits needs a human-readable name.
+        for label in ("imports", "calls", "depends on", "inherits", "contains"):
+            self.assertIn('"%s"' % label, tpl, "no label for edge kind %r" % label)
+
+    def test_live_edges_are_capped(self):
+        """A high-degree hub must not blow the frame budget (was 1341 edges/36ms)."""
+        tpl = render.load_template()
+        self.assertRegex(tpl, r"LIVE_EDGE_CAP\s*=\s*\d+")
+        cap = int(re.search(r"LIVE_EDGE_CAP\s*=\s*(\d+)", tpl).group(1))
+        self.assertLessEqual(cap, 200, "cap too high to hold 60fps")
+        self.assertGreaterEqual(cap, 40, "cap so low the effect disappears")
+
+    def test_two_views_wired(self):
+        """The merged contract: an overview view, an explore view, and the handoff."""
+        tpl = render.load_template()
+        for token in ('id="ov"', 'id="mOverview"', 'id="mExplore"',
+                      "function setMode", "function drillInto", "function buildOverview",
+                      "ov-box", "ov-link", "ov-comet", "animateMotion"):
+            self.assertIn(token, tpl, "merged view lost %r" % token)
+
+    def test_static_and_motion_use_separate_canvases(self):
+        """Perf contract: the cached scene must not be repainted every frame."""
+        tpl = render.load_template()
+        self.assertIn('<canvas id="cv">', tpl)
+        self.assertIn('<canvas id="fx">', tpl)
+        self.assertIn("#fx{pointer-events:none}", tpl.replace(" ", "").replace("\n", ""))
+
+
+class TestRendering(Base):
+    def test_produces_self_contained_html(self):
+        html = render.render_html(self.graph, "fixture")
+        self.assertTrue(html.startswith("<!DOCTYPE html>"))
+        self.assertNotIn("__DATA__", html)
+        self.assertNotIn("__TITLE__", html)
+        # No external resource loads: fully offline artifact.
+        for bad in ('src="http', 'href="http', "cdn.", "unpkg", "googleapis"):
+            self.assertNotIn(bad, html)
+
+    def test_embedded_json_is_parseable_and_escaped(self):
+        html = render.render_html(self.graph, "fixture")
+        start = html.index('<script id="data" type="application/json">') + \
+            len('<script id="data" type="application/json">')
+        end = html.index("</script>", start)
+        payload = html[start:end]
+        # The payload must not contain a raw closing tag that would break the script.
+        self.assertNotIn("</script", payload)
+        data = json.loads(payload.replace("<\\/", "</"))
+        self.assertEqual(len(data["nodes"]), len(self.graph["nodes"]))
+
+    def test_slim_drops_internal_fields(self):
+        slimmed = render.slim(self.graph)
+        allowed_node_keys = {
+            "id", "type", "name", "filePath", "module", "language", "layer", "loc",
+            "fanIn", "fanOut", "importance", "isEntry", "defCount", "routes",
+            "httpVerbs", "title", "summary", "tags", "lineRange", "kind",
+            "fileCount", "languages", "usedBy", "importCount",
+            "doc", "symbols", "summarySource", "parent", "depth", "ownFiles",
+        }
+        for n in slimmed["nodes"]:
+            self.assertTrue(set(n).issubset(allowed_node_keys),
+                            "unexpected keys survived slim(): %s" % (set(n) - allowed_node_keys))
+        for e in slimmed["edges"]:
+            self.assertTrue(set(e).issubset({"source", "target", "type", "line"}))
+        # Empty values are stripped to keep the embedded payload small.
+        for n in slimmed["nodes"]:
+            self.assertNotIn("", n.values())
+
+    def test_atomic_delivery_writes_file(self):
+        out = os.path.join(self.tmp, "out", "codegraph.html")
+        render.deliver(render.render_html(self.graph, "t"), out)
+        self.assertTrue(os.path.isfile(out))
+        self.assertGreater(os.path.getsize(out), 5000)
+
+    def test_failed_render_leaves_no_partial_file(self):
+        out = os.path.join(self.tmp, "fail", "codegraph.html")
+        with self.assertRaises(ValueError):
+            render.deliver("no placeholders replaced __DATA__", out)
+        self.assertFalse(os.path.exists(out))
+        leftovers = [f for f in os.listdir(os.path.dirname(out))
+                     if f.startswith(".codegraph-")]
+        self.assertEqual(leftovers, [])
+
+
+class TestCLI(Base):
+    def test_end_to_end_cli(self):
+        out_dir = os.path.join(self.tmp, "cli", ".codegraph")
+        r1 = subprocess.run(
+            [sys.executable, os.path.join(HERE, "scan.py"), self.repo, "-o", out_dir],
+            capture_output=True, text=True)
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(out_dir, "graph.json")))
+        self.assertTrue(os.path.isfile(os.path.join(out_dir, "digest.md")))
+
+        r2 = subprocess.run(
+            [sys.executable, os.path.join(HERE, "render.py"), "--in", out_dir],
+            capture_output=True, text=True)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(out_dir, "codegraph.html")))
+
+    def test_validate_only_writes_nothing(self):
+        out_dir = os.path.join(self.tmp, "vo", ".codegraph")
+        subprocess.run([sys.executable, os.path.join(HERE, "scan.py"), self.repo,
+                        "-o", out_dir, "--quiet"], check=True)
+        r = subprocess.run(
+            [sys.executable, os.path.join(HERE, "render.py"), "--in", out_dir,
+             "--validate-only"], capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(os.path.exists(os.path.join(out_dir, "codegraph.html")))
+
+    def test_render_fails_without_graph(self):
+        r = subprocess.run(
+            [sys.executable, os.path.join(HERE, "render.py"), "--in",
+             os.path.join(self.tmp, "nonexistent")], capture_output=True, text=True)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("scan.py first", r.stderr)
+
+    def test_scan_rejects_bad_path(self):
+        r = subprocess.run(
+            [sys.executable, os.path.join(HERE, "scan.py"),
+             os.path.join(self.tmp, "nope")], capture_output=True, text=True)
+        self.assertNotEqual(r.returncode, 0)
+
+
+class TestEdgeCases(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="codegraph-edge-")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_empty_repo_exits_cleanly(self):
+        empty = os.path.join(self.tmp, "empty")
+        os.makedirs(empty)
+        r = subprocess.run([sys.executable, os.path.join(HERE, "scan.py"), empty],
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("no source files", r.stderr)
+
+    def test_single_file_repo(self):
+        one = os.path.join(self.tmp, "one")
+        os.makedirs(one)
+        with open(os.path.join(one, "a.py"), "w") as fh:
+            fh.write("def f():\n    return 1\n")
+        scanned = scan.scan(one, 4000, True, 250)
+        graph = scan.build_graph(scanned)
+        errors, _ = render.validate_graph(graph)
+        self.assertEqual(errors, [])
+        html = render.render_html(graph, "one")
+        self.assertTrue(html.startswith("<!DOCTYPE html>"))
+        self.assertIn("file:a.py", html)
+
+    def test_unicode_and_quotes_survive_render(self):
+        u = os.path.join(self.tmp, "uni")
+        os.makedirs(u)
+        with open(os.path.join(u, "emoji.py"), "w", encoding="utf-8") as fh:
+            fh.write('"""Docs with "quotes" and 中文 and \\ backslash."""\n\ndef f():\n    return 1\n')
+        graph = scan.build_graph(scan.scan(u, 4000, True, 250))
+        clean, _ = render.validate_enrich(
+            {"nodes": {"file:emoji.py": {"summary": 'Has "quotes", 中文, </script> and \\ chars'}}},
+            {n["id"] for n in graph["nodes"]})
+        merged = render.merge(graph, clean)
+        html = render.render_html(merged, "uni")
+        self.assertNotIn("</script>", html[html.index('id="data"'):html.index("</script>",
+                                                                             html.index('id="data"'))])
+        self.assertIn("中文", html)
+
+    def test_file_without_trailing_newline(self):
+        p = os.path.join(self.tmp, "nonl")
+        os.makedirs(p)
+        with open(os.path.join(p, "x.py"), "w") as fh:
+            fh.write("def f(): pass")
+        graph = scan.build_graph(scan.scan(p, 4000, True, 250))
+        self.assertTrue(any(n["id"] == "file:x.py" for n in graph["nodes"]))
+
+    def test_max_files_truncation_is_reported(self):
+        many = os.path.join(self.tmp, "many")
+        os.makedirs(many)
+        for i in range(12):
+            with open(os.path.join(many, "m%d.py" % i), "w") as fh:
+                fh.write("x = %d\n" % i)
+        scanned = scan.scan(many, max_files=5, want_calls=False, symbols_for=10)
+        self.assertTrue(scanned["stats"]["truncated"])
+        self.assertLessEqual(scanned["stats"]["files_indexed"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2 if "-v" in sys.argv else 1)

--- a/skills/codegraph/scripts/viewer.html
+++ b/skills/codegraph/scripts/viewer.html
@@ -1,0 +1,2589 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>__TITLE__ · codegraph</title>
+<style>
+:root{
+  /* Deep-field palette: near-black navy canvas, cool ink, glass chrome. */
+  --bg:#04050c; --bg2:rgba(140,165,255,.055); --bg3:rgba(140,165,255,.10);
+  --panel:rgba(11,15,30,.52); --panel-solid:rgba(9,12,26,.86);
+  --line:rgba(160,180,255,.12); --line2:rgba(160,180,255,.20);
+  --fg:rgba(235,240,255,.94); --fg2:rgba(235,240,255,.62); --fg3:rgba(235,240,255,.38);
+  --accent:#8ec8ff; --accent2:#c98cff; --hot:#ffd98a;
+  --shadow:0 24px 80px rgba(0,0,0,.55), inset 0 1px 0 rgba(190,205,255,.07);
+  --radius:14px;
+  --blur:blur(16px) saturate(1.3);
+  --track:.18em;
+}
+html[data-theme="light"]{
+  --bg:#eef1f7; --bg2:rgba(40,70,140,.05); --bg3:rgba(40,70,140,.10);
+  --panel:rgba(255,255,255,.72); --panel-solid:rgba(255,255,255,.94);
+  --line:rgba(30,50,110,.13); --line2:rgba(30,50,110,.22);
+  --fg:#141a2c; --fg2:rgba(20,26,44,.66); --fg3:rgba(20,26,44,.42);
+  --accent:#2563eb; --accent2:#7c3aed; --hot:#b45309;
+  --shadow:0 18px 50px rgba(20,30,60,.14), inset 0 1px 0 rgba(255,255,255,.7);
+}
+*{box-sizing:border-box}
+html,body{height:100%;margin:0}
+body{
+  background:var(--bg); color:var(--fg); overflow:hidden;
+  font:13px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  -webkit-font-smoothing:antialiased;
+}
+#stage{position:fixed;inset:0}
+canvas{position:absolute;inset:0;display:block;width:100%;height:100%}
+#cv{cursor:grab}
+#cv.dragging{cursor:grabbing}
+/* The overlay only paints motion; all pointer input belongs to the base canvas. */
+#fx{pointer-events:none}
+
+/* Glass chrome, lifted off the canvas by blur + inner highlight.
+   Explicit stacking order — the views are z-index 1-2, so every floating panel
+   must sit above them or the view layer eats its clicks:
+     canvases 0 · views 1-2 · panels 10 · tour 20 · tooltip 99 */
+.panel{position:fixed;background:var(--panel);border:1px solid var(--line);
+  border-radius:var(--radius);box-shadow:var(--shadow);z-index:10;
+  backdrop-filter:var(--blur); -webkit-backdrop-filter:var(--blur)}
+
+/* HUD wakes up in a staggered cascade, like the atlas opening. */
+@keyframes hudIn{from{opacity:0;transform:translateY(-6px)}}
+@keyframes hudInUp{from{opacity:0;transform:translateY(8px)}}
+#top{animation:hudIn .9s cubic-bezier(.22,1,.36,1) backwards}
+#rail{animation:hudIn 1s cubic-bezier(.22,1,.36,1) .18s backwards}
+#help{animation:hudInUp 1s ease .5s backwards}
+@media (prefers-reduced-motion:reduce){
+  #top,#rail,#help{animation:none}
+}
+
+/* ---- top bar ---- */
+#top{top:12px;left:12px;right:12px;display:flex;gap:8px;align-items:center;
+  padding:8px 10px;flex-wrap:wrap}
+#top h1{font-size:13px;margin:0 8px 0 4px;font-weight:500;white-space:nowrap;
+  letter-spacing:.16em;text-indent:.16em;
+  text-shadow:0 0 24px rgba(120,150,255,.35)}
+#top h1 small{color:var(--fg3);font-weight:400;margin-left:8px;
+  font-size:9.5px;letter-spacing:.22em;text-transform:uppercase;text-shadow:none}
+#search{flex:1;min-width:170px;background:var(--bg2);border:1px solid var(--line);
+  color:var(--fg);padding:7px 14px;border-radius:999px;font:inherit;outline:none;
+  letter-spacing:.06em;transition:border-color .3s,background .3s}
+#search::placeholder{color:var(--fg3);letter-spacing:.1em}
+#search:focus{border-color:var(--line2);background:var(--bg3)}
+button,select{background-color:var(--bg2);color:var(--fg2);border:1px solid var(--line);
+  border-radius:999px;padding:6px 13px;font:inherit;font-size:11.5px;cursor:pointer;
+  white-space:nowrap;letter-spacing:.12em;
+  transition:color .35s ease,background-color .35s ease,border-color .35s ease,box-shadow .35s ease}
+/* The dropdown LIST is painted by the OS, not by our CSS — color-scheme is the
+   only way to make it follow the theme. Without it the popup stays white. */
+select{border-radius:999px;padding:6px 26px 6px 11px;color-scheme:dark;
+  appearance:none;-webkit-appearance:none;
+  background-image:linear-gradient(45deg,transparent 50%,var(--fg2) 50%),
+                   linear-gradient(135deg,var(--fg2) 50%,transparent 50%);
+  background-position:calc(100% - 14px) 52%,calc(100% - 9px) 52%;
+  background-size:5px 5px,5px 5px;background-repeat:no-repeat}
+html[data-theme="light"] select{color-scheme:light}
+/* Explicit option colors for the platforms that honour them (Windows/Linux). */
+select option{background:#0b1020;color:#e8ecf8}
+html[data-theme="light"] select option{background:#fff;color:#141a2c}
+button:hover{color:var(--fg);background:var(--bg3)}
+/* Only recolor the select on hover — a background shorthand would wipe the arrow. */
+select:hover{color:var(--fg);background-color:var(--bg3);border-color:var(--line2)}
+button:disabled{opacity:.35;cursor:default}
+button:disabled:hover{color:var(--fg2);background:var(--bg2)}
+/* Active toggles glow rather than invert — keeps the dark canvas calm. */
+button.on{color:var(--fg);background:var(--bg3);border-color:var(--line2);
+  box-shadow:0 0 0 1px var(--line2),0 0 16px -2px var(--accent);
+  text-shadow:0 0 12px var(--accent)}
+.sep{width:1px;height:18px;background:var(--line);margin:0 3px}
+
+/* ---- overview: authored-looking architecture diagram (glowmotion idiom) ---- */
+#modes{display:flex;gap:3px;padding:2px;border:1px solid var(--line);border-radius:999px;
+  background:var(--bg2)}
+#modes button{border:0;background:transparent;padding:5px 13px}
+#modes button.on{background:var(--bg3);border-color:transparent}
+#ov{position:fixed;inset:56px 0 0 0;overflow:auto;display:none;z-index:1}
+#ov.show{display:block}
+#ovScroll{min-height:100%;display:flex;flex-direction:column;align-items:center;
+  justify-content:center;gap:6px;padding:26px 26px 84px}
+#ovSvg{max-width:min(1180px,100%);height:auto;overflow:visible}
+
+/* rows read as faint architectural bands */
+.ov-band{fill:currentColor;opacity:.05}
+.ov-bandlabel{font:400 8px ui-sans-serif,system-ui,sans-serif;letter-spacing:.26em;
+  fill:currentColor;opacity:.75;text-transform:uppercase}
+
+/* module boxes: glow ring + translucent fill, like a lit component */
+.ov-box{cursor:pointer}
+.ov-box rect{fill:var(--ovFill);stroke:currentColor;stroke-width:1.2;
+  transition:filter .35s ease,stroke-width .35s ease}
+.ov-box:hover rect{stroke-width:2;filter:drop-shadow(0 0 10px currentColor)}
+.ov-box.hot rect{stroke-width:2}
+.ov-name{font:600 10.5px ui-sans-serif,system-ui,sans-serif;fill:var(--fg);
+  letter-spacing:.02em;pointer-events:none}
+.ov-meta{font:400 7.5px ui-monospace,"SF Mono",Menlo,monospace;fill:var(--fg3);
+  letter-spacing:.06em;pointer-events:none}
+.ov-badge{font:400 7px ui-sans-serif,system-ui,sans-serif;fill:currentColor;
+  letter-spacing:.14em;text-transform:uppercase;pointer-events:none;opacity:.9}
+
+/* connectors: dash-flow animation carries direction without any JS */
+.ov-link{fill:none;stroke:var(--ovLink);stroke-width:1;opacity:.4;
+  stroke-dasharray:5 4;animation:ovFlow 1.1s linear infinite}
+.ov-link.heavy{stroke-width:1.7;opacity:.62}
+.ov-link.path{stroke:var(--accent);opacity:.9;stroke-width:1.8;stroke-dasharray:none;
+  filter:drop-shadow(0 0 5px var(--accent))}
+@keyframes ovFlow{to{stroke-dashoffset:-18}}
+
+/* the journey comet: a dot riding the authored route, with two fading trails */
+.ov-comet{fill:var(--accent);filter:drop-shadow(0 0 6px var(--accent))}
+.ov-trail{fill:var(--accent);opacity:.4}
+.ov-halo{fill:none;stroke:var(--accent);opacity:0;animation:ovHalo 2.6s ease-in-out infinite}
+@keyframes ovHalo{
+  0%,100%{opacity:0;stroke-width:1}
+  40%{opacity:.55;stroke-width:2}
+}
+.ov-arrow{fill:var(--ovLink);opacity:.55}
+.ov-arrow.path{fill:var(--accent);opacity:.95}
+
+#ovLegend{position:fixed;bottom:14px;left:50%;transform:translateX(-50%);
+  display:flex;gap:16px;align-items:center;font-size:10px;letter-spacing:.14em;
+  color:var(--fg3);padding:7px 16px;z-index:2;display:none}
+#ovLegend.show{display:flex}
+#ovLegend i{display:inline-block;width:16px;height:0;border-top:1.6px solid;
+  margin-right:6px;vertical-align:middle}
+#ovHint{text-align:center;color:var(--fg3);font-size:11px;line-height:1.7;
+  letter-spacing:.04em;margin-top:20px;max-width:min(720px,90%)}
+
+html[data-theme="dark"]{--ovFill:rgba(12,18,36,.72);--ovLink:#8ea6d8}
+html[data-theme="light"]{--ovFill:rgba(255,255,255,.9);--ovLink:#5b6b8c}
+/* ⏸ stops the CSS dash-flow; SMIL comets are paused via pauseAnimations() */
+#ov.paused .ov-link,#ov.paused .ov-halo{animation-play-state:paused}
+@media (prefers-reduced-motion:reduce){
+  .ov-link,.ov-halo{animation:none}
+}
+
+/* ---- star map: the Physics-atlas reading of the same graph ---- */
+#sky{position:fixed;inset:56px 0 0 0;display:none;z-index:1;
+  background:radial-gradient(ellipse at 50% 45%,#0a1024 0%,#04050c 62%,#020307 100%)}
+#sky.show{display:block}
+#skyCv{position:absolute;inset:0;width:100%;height:100%;cursor:crosshair}
+#skyHint{position:absolute;bottom:16px;left:0;right:0;text-align:center;
+  font-size:10px;letter-spacing:.26em;color:var(--fg3);pointer-events:none;
+  text-transform:uppercase}
+html[data-theme="light"] #sky{
+  background:radial-gradient(ellipse at 50% 45%,#fbfcff 0%,#eef1f7 60%,#e6eaf3 100%)}
+
+/* ---- left rail ---- */
+#rail{left:12px;top:64px;width:212px;max-height:calc(100vh - 92px);overflow-y:auto;padding:10px}
+#rail h2{font-size:9.5px;text-transform:uppercase;letter-spacing:.28em;color:var(--fg3);
+  margin:2px 0 9px;font-weight:400}
+#rail section{margin-bottom:16px}
+.lyr{display:flex;align-items:center;gap:8px;padding:4px 7px;border-radius:999px;cursor:pointer;
+  font-size:11.5px;user-select:none;letter-spacing:.05em;border:1px solid transparent;
+  transition:color .4s ease,background .4s ease,border-color .4s ease}
+.lyr:hover{color:var(--fg);background:var(--bg2)}
+.lyr.on{background:var(--bg3);border-color:var(--line)}
+.lyr.off{opacity:.3}
+.dot{width:7px;height:7px;border-radius:50%;flex:none;
+  box-shadow:0 0 10px currentColor;transition:box-shadow .4s ease}
+.lyr:hover .dot{box-shadow:0 0 16px currentColor}
+.lyr .ct{margin-left:auto;color:var(--fg3);font-size:9.5px;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace}
+.stat{display:flex;justify-content:space-between;font-size:11px;color:var(--fg2);padding:2px 6px;
+  letter-spacing:.05em}
+.stat b{color:var(--fg);font-weight:500;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;font-size:11.5px}
+#hits{list-style:none;margin:0;padding:0;max-height:210px;overflow-y:auto}
+#hits li{padding:5px 8px;border-radius:8px;cursor:pointer;font-size:11.5px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;letter-spacing:.04em;
+  transition:background .25s,color .25s}
+#hits li:hover{background:var(--bg3);color:var(--accent)}
+/* "Start here": the entry points, so a new reader has an obvious first click. */
+#entryList div{padding:5px 8px;border-radius:8px;cursor:pointer;font-size:11.5px;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;letter-spacing:.03em;
+  color:var(--fg2);transition:background .25s,color .25s}
+#entryList div:hover{background:var(--bg3);color:var(--accent)}
+#entryList div b{color:var(--fg);font-weight:500}
+#entryList div i{font-style:normal;color:var(--fg3);font-size:9.5px;
+  display:block;letter-spacing:.02em}
+
+/* ---- inspector ---- */
+#info{right:12px;top:64px;width:322px;max-height:calc(100vh - 92px);overflow-y:auto;
+  padding:12px;display:none}
+#info.show{display:block}
+#info{animation:hudIn .5s cubic-bezier(.22,1,.36,1)}
+#info .kind{font-size:9px;text-transform:uppercase;letter-spacing:.3em;color:var(--accent);
+  font-weight:400;display:flex;align-items:center;justify-content:space-between;gap:8px}
+#info .kind button{font-size:9px;letter-spacing:.18em;padding:3px 9px;text-transform:none}
+#info h3{margin:8px 0 3px;font-size:17px;word-break:break-word;line-height:1.3;
+  font-weight:500;letter-spacing:.06em;text-shadow:0 0 18px rgba(140,170,255,.3)}
+#info .path{color:var(--fg3);font-size:10px;word-break:break-all;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;margin-bottom:11px;letter-spacing:.02em}
+#info .sum{font-size:12.5px;line-height:1.75;color:var(--fg);background:var(--bg2);
+  padding:10px 12px;border-radius:10px;margin-bottom:11px;letter-spacing:.02em;
+  border-left:2px solid var(--accent);box-shadow:inset 0 0 24px -8px var(--accent)}
+#info .sum.none{color:var(--fg3);border-left-color:var(--line);font-style:italic;box-shadow:none}
+/* Extracted-from-source summaries are labelled, so their provenance is honest. */
+#info .sum.doc{border-left-color:var(--fg3);box-shadow:none}
+#info .sum i{display:block;margin-top:6px;font-size:9px;font-style:normal;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--fg3)}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-bottom:11px}
+.cell{background:var(--bg2);border-radius:9px;padding:6px 9px;border:1px solid var(--line)}
+.cell .k{font-size:8.5px;text-transform:uppercase;color:var(--fg3);letter-spacing:.2em}
+.cell .v{font-size:13px;font-weight:500;margin-top:1px;letter-spacing:0;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.tags{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:11px}
+.tag{background:var(--bg2);border:1px solid var(--line);color:var(--fg2);
+  border-radius:999px;padding:2px 10px;font-size:10px;letter-spacing:.1em}
+#info h4{font-size:9px;text-transform:uppercase;letter-spacing:.26em;color:var(--fg3);
+  margin:14px 0 6px;display:flex;justify-content:space-between;font-weight:400}
+.rel{list-style:none;margin:0;padding:0}
+.rel li{padding:4px 7px;border-radius:7px;cursor:pointer;font-size:11.5px;
+  display:flex;gap:8px;align-items:baseline;transition:background .25s}
+.rel li:hover{background:var(--bg3)}
+.rel .ico{color:var(--fg3);font-size:8.5px;flex:none;width:46px;letter-spacing:.06em;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rel .nm{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--accent)}
+.empty{color:var(--fg3);font-size:11px;font-style:italic;padding:2px 6px}
+
+/* ---- tour ---- */
+/* Above #ov (z-index:1), or the overview's scroll layer swallows the tour's
+   own Prev/Next/Close buttons and the panel becomes uncontrollable. */
+#tour{bottom:16px;left:50%;transform:translateX(-50%) translateY(14px);
+  width:min(680px,calc(100vw - 32px));padding:15px 20px 17px;z-index:20;
+  opacity:0;pointer-events:none;display:block;
+  transition:opacity .5s ease,transform .5s cubic-bezier(.22,1,.36,1)}
+#tour.show{opacity:1;pointer-events:auto;transform:translateX(-50%) translateY(0)}
+#tour .hd{display:flex;align-items:center;gap:11px;margin-bottom:7px}
+#tour .ti{font-weight:500;font-size:12px;letter-spacing:.22em;text-transform:uppercase;
+  color:var(--fg)}
+#tour .ct{margin-left:auto;color:var(--fg3);font-size:10px;
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.04em}
+#tour .note{font-size:13.5px;line-height:1.85;color:var(--fg2);min-height:44px;
+  letter-spacing:.03em;transition:opacity .35s ease}
+#tour.swap .note{opacity:0}
+#tour .note b{color:var(--accent);font-weight:500;
+  text-shadow:0 0 14px color-mix(in srgb,var(--accent) 60%,transparent)}
+#bar{height:1px;background:var(--line);border-radius:1px;margin-top:11px;overflow:hidden}
+#bar div{height:100%;transition:width .4s cubic-bezier(.22,1,.36,1);
+  background:linear-gradient(90deg,
+    color-mix(in srgb,var(--accent) 55%,transparent),var(--accent))}
+
+#tip{position:fixed;pointer-events:none;background:var(--panel-solid);color:var(--fg);
+  padding:5px 10px;border:1px solid var(--line);border-radius:8px;font-size:10.5px;
+  display:none;z-index:99;max-width:360px;letter-spacing:.03em;
+  backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);
+  font-family:ui-monospace,"SF Mono",Menlo,monospace;box-shadow:0 8px 30px rgba(0,0,0,.5)}
+#help{position:fixed;bottom:14px;right:16px;color:var(--fg3);font-size:10px;text-align:right;
+  line-height:1.9;pointer-events:none;letter-spacing:.16em}
+kbd{background:var(--bg2);border:1px solid var(--line);border-radius:4px;padding:0 5px;
+  font-size:9px;font-family:ui-monospace,"SF Mono",Menlo,monospace;color:var(--fg2)}
+#empty{position:fixed;inset:0;display:none;place-items:center;color:var(--fg3);font-size:12px;
+  letter-spacing:.2em}
+::-webkit-scrollbar{width:7px;height:7px}
+::-webkit-scrollbar-thumb{background:var(--line2);border-radius:4px}
+::-webkit-scrollbar-thumb:hover{background:var(--accent)}
+::-webkit-scrollbar-track{background:transparent}
+</style>
+</head>
+<body>
+<div id="stage">
+  <canvas id="cv"></canvas>
+  <!-- Motion overlay: starfield, comet packets and halos. Static scene stays cached below. -->
+  <canvas id="fx"></canvas>
+</div>
+<!-- Overview: the glowmotion-style architecture diagram. Crisp SVG, CSS/SMIL
+     animated, click a module to drill into the explore view. -->
+<div id="ov"><div id="ovScroll"></div></div>
+<!-- Star map: the same modules read as mass instead of layers. Canvas, because
+     hundreds of glowing sprites are cheaper to paint than to put in the DOM. -->
+<div id="sky"><canvas id="skyCv"></canvas><div id="skyHint"></div></div>
+<div id="empty">No nodes match the current filters.</div>
+
+<div class="panel" id="top">
+  <h1>__TITLE__<small id="sub"></small></h1>
+  <input id="search" placeholder="Search files, symbols, folders…  (press /)" autocomplete="off" spellcheck="false">
+  <div class="sep"></div>
+  <div id="modes" role="tablist" aria-label="View">
+    <button id="mOverview" class="on" role="tab" title="Architecture overview (Tab)">overview</button>
+    <button id="mStar" role="tab" title="Star map — mass and clustering (Tab)">star map</button>
+    <button id="mExplore" role="tab" title="Explore every file (Tab)">explore</button>
+  </div>
+  <div class="sep"></div>
+  <select id="view" title="Detail level">
+    <option value="module">Folders</option>
+    <option value="file" selected>Files</option>
+    <option value="symbol">Symbols</option>
+  </select>
+  <button id="bImports" class="on" title="Show import edges">imports</button>
+  <button id="bCalls" title="Show inferred call edges">calls</button>
+  <button id="bExt" title="Show external dependencies">deps</button>
+  <div class="sep"></div>
+  <button id="bHier" class="on" title="Expand level by level from the project root (H)">layers</button>
+  <button id="bFold" class="on" title="Fold edges of hub files (F) — biggest declutter">simplify</button>
+  <button id="bHood" title="Show only the selected node and its direct neighbours (N)">focus</button>
+  <button id="bEntry" title="Highlight entry points">entries</button>
+  <button id="bCycles" title="Highlight dependency cycles">cycles</button>
+  <button id="bTour" title="Guided tours">tour</button>
+  <div class="sep"></div>
+  <button id="bFit" title="Fit to view (0)">fit</button>
+  <button id="bMotion" class="on" title="Pause / resume motion (space)">⏸</button>
+  <button id="bTheme" title="Toggle theme (T)">◐</button>
+</div>
+
+<div class="panel" id="rail">
+  <section id="startHere" style="display:none">
+    <h2>Start here</h2>
+    <div id="entryList"></div>
+  </section>
+  <section>
+    <h2>Overview</h2>
+    <div id="stats"></div>
+  </section>
+  <section>
+    <h2>Layers</h2>
+    <div id="layers"></div>
+  </section>
+  <section id="hitsWrap" style="display:none">
+    <h2>Matches</h2>
+    <ul id="hits"></ul>
+  </section>
+</div>
+
+<div class="panel" id="info"></div>
+
+<div class="panel" id="tour">
+  <div class="hd">
+    <span class="ti" id="tTitle"></span>
+    <span class="ct" id="tCount"></span>
+    <button id="tPrev" title="Previous ([)">‹</button>
+    <button id="tNext" title="Next (])">›</button>
+    <button id="tClose" title="Close">✕</button>
+  </div>
+  <div class="note" id="tNote"></div>
+  <div id="bar"><div style="width:0"></div></div>
+</div>
+
+<div class="panel" id="ovLegend">
+  <span><i style="border-top-style:dashed"></i>imports</span>
+  <span><i style="border-color:var(--accent)"></i>primary path</span>
+  <span style="opacity:.8">click a module to explore its files</span>
+</div>
+
+<div id="tip"></div>
+<div id="help">
+  <div><kbd>Tab</kbd> overview / explore · <kbd>F</kbd> simplify · <kbd>N</kbd> focus · <kbd>/</kbd> search · <kbd>0</kbd> fit · <kbd>T</kbd> theme · <kbd>P</kbd> tour · <kbd>space</kbd> motion</div>
+  <div>click a hub's <b>⋯n</b> badge to reveal its edges · drag to pan · scroll to zoom</div>
+</div>
+
+<script id="data" type="application/json">__DATA__</script>
+<script>
+"use strict";
+const G = JSON.parse(document.getElementById("data").textContent);
+
+/* ------------------------------------------------------------------ palette */
+const LAYER_COLORS = {
+  entry:"#f472b6", ui:"#38bdf8", api:"#22d3ee", service:"#a78bfa", data:"#34d399",
+  util:"#94a3b8", config:"#fbbf24", infra:"#fb923c", test:"#64748b", docs:"#4ade80",
+  other:"#7c8797", external:"#475569"
+};
+const LAYER_NAMES = {};
+(G.layers||[]).forEach(l => LAYER_NAMES[l.id] = l.name);
+const layerColor = id => LAYER_COLORS[id] || LAYER_COLORS.other;
+
+/* ------------------------------------------------------------------ indexes */
+const NODES = G.nodes, EDGES = G.edges;
+const byId = new Map(NODES.map(n => [n.id, n]));
+const cycleSet = new Set((G.cycles||[]).flat());
+/** Append to a Map-of-arrays bucket. */
+function bucket(map, key) {
+  let arr = map.get(key);
+  if (!arr) { arr = []; map.set(key, arr); }
+  return arr;
+}
+const adjOut = new Map(), adjIn = new Map();
+for (const e of EDGES) {
+  if (e.type === "contains") continue;
+  bucket(adjOut, e.source).push(e);
+  bucket(adjIn, e.target).push(e);
+}
+const childrenOf = new Map();
+for (const e of EDGES) {
+  if (e.type !== "contains") continue;
+  bucket(childrenOf, e.source).push(e.target);
+}
+
+const STRUCT = { module:0, file:1, symbol:2 };
+function tier(n) {
+  if (n.type === "module") return 0;
+  if (n.type === "external") return 1;
+  if (n.type === "file" || n.type === "config" || n.type === "document") return 1;
+  return 2;
+}
+
+/* ------------------------------------------------------------------ state */
+const S = {
+  mode: "overview",        // "overview" (authored diagram) | "explore" (full graph)
+  view: "file",
+  imports: true, calls: false, ext: false,
+  entries: false, cycles: false,
+  // Declutter defaults. A dense repo is unreadable with every edge drawn, so we
+  // start simple and let the reader add detail — the reverse of the old default.
+  // Hierarchy mode is the default way into explore: start at the root and open
+  // one level at a time. Flat mode (the old behaviour) stays one click away.
+  hier: true,
+  open: new Set(),         // expanded module ids
+  openFiles: new Set(),    // files whose symbols are revealed
+  foldHubs: true,          // collapse edges of very high-degree nodes
+  neighborhood: false,     // show only the selection and its direct neighbours
+  expanded: new Set(),     // hubs the reader explicitly opened
+  // Tests are often half a repo's files but are not its architecture, so they
+  // start hidden. The layer chip in the rail turns them back on.
+  hiddenLayers: new Set(["test"]),
+  query: "", selected: null, hover: null,
+  tourIdx: -1, tourStep: 0,
+  tx: 0, ty: 0, scale: 1,
+};
+
+let VN = [], VE = [];   // visible nodes / edges
+let BANDS = [];         // [{id, top, bottom, count}] vertical layer bands
+
+/* ---------------------------------------------------------------- hierarchy
+   Progressive disclosure. Instead of dumping every file at once, the explore
+   view starts at the project root and reveals one level per click, the way you
+   actually read an unfamiliar repo: what are the top folders -> which one holds
+   the entry point -> what is inside it -> which file do I open.
+
+   S.open holds the module ids the reader has expanded. A module's children are
+   visible only when the module itself is open; everything else collapses into
+   its nearest open ancestor. */
+
+const MOD_KIDS = new Map();          // module id -> child module ids
+const MOD_FILES = new Map();         // module id -> files directly inside
+for (const n of NODES) {
+  if (n.type === "module" && n.parent) bucket(MOD_KIDS, n.parent).push(n.id);
+}
+for (const n of NODES) {
+  if (n.module && (n.type === "file" || n.type === "config" || n.type === "document"))
+    bucket(MOD_FILES, n.module).push(n.id);
+}
+const ROOT_MOD = (NODES.find(n => n.type === "module" && !n.parent) || {}).id || "mod:.";
+
+/** Ancestor chain of a module, root first. */
+function modChain(id) {
+  const out = [];
+  let cur = byId.get(id);
+  while (cur) { out.unshift(cur.id); cur = cur.parent ? byId.get(cur.parent) : null; }
+  return out;
+}
+
+/** Open a module and every ancestor, so a deep target is actually reachable. */
+function openTo(id) {
+  for (const m of modChain(id)) S.open.add(m);
+}
+
+function visibleNodes() {
+  if (!S.hier) {                      // flat mode: the original behaviour
+    const want = STRUCT[S.view];
+    return NODES.filter(n => {
+      if (n.type === "external") return S.ext;
+      if (tier(n) > want) return false;
+      if (S.hiddenLayers.has(n.layer || "other")) return false;
+      return true;
+    });
+  }
+  const out = [];
+  const layerOk = n => !S.hiddenLayers.has(n.layer || "other");
+
+  // Walk the module tree; recurse only into open nodes.
+  const walk = id => {
+    const kids = MOD_KIDS.get(id) || [];
+    const files = MOD_FILES.get(id) || [];
+    if (S.open.has(id)) {
+      for (const k of kids) {
+        const kn = byId.get(k);
+        if (kn && layerOk(kn)) { out.push(kn); walk(k); }
+      }
+      // A module's own files appear once it is open.
+      for (const f of files) {
+        const fn = byId.get(f);
+        if (fn && layerOk(fn)) out.push(fn);
+      }
+    }
+  };
+  const rootNode = byId.get(ROOT_MOD);
+  if (rootNode) out.push(rootNode);
+  walk(ROOT_MOD);
+
+  // Symbols only for files the reader explicitly opened — never in bulk.
+  for (const fid of S.openFiles) {
+    for (const sid of (childrenOf.get(fid) || [])) {
+      const sn = byId.get(sid);
+      if (sn && sn.id.startsWith("sym:")) out.push(sn);
+    }
+  }
+  if (S.ext) for (const n of NODES) if (n.type === "external") out.push(n);
+  return out;
+}
+
+/** Does this node have anything left to reveal? Drives the +N affordance. */
+function hiddenChildCount(n) {
+  if (n.type === "module") {
+    if (S.open.has(n.id)) return 0;
+    return (MOD_KIDS.get(n.id) || []).length + (MOD_FILES.get(n.id) || []).length;
+  }
+  if (n.type === "file") {
+    if (S.openFiles.has(n.id)) return 0;
+    return (childrenOf.get(n.id) || []).length;
+  }
+  return 0;
+}
+
+/** Click behaviour in hierarchy mode: expand or collapse one level. */
+function toggleExpand(id) {
+  const n = byId.get(id);
+  if (!n) return false;
+  if (n.type === "module") {
+    S.open.has(id) ? S.open.delete(id) : S.open.add(id);
+  } else if (n.type === "file" && (childrenOf.get(id) || []).length) {
+    S.openFiles.has(id) ? S.openFiles.delete(id) : S.openFiles.add(id);
+  } else return false;
+  rebuild();
+  draw();
+  return true;
+}
+
+/** Lift an edge endpoint up to the deepest ancestor that is actually visible. */
+function liftMap(vset) {
+  const parent = new Map();
+  for (const [src, kids] of childrenOf) for (const k of kids) parent.set(k, src);
+  const cache = new Map();
+  return function lift(id) {
+    if (vset.has(id)) return id;
+    if (cache.has(id)) return cache.get(id);
+    let cur = id, out = null, guard = 0;
+    while (cur && guard++ < 12) {
+      cur = parent.get(cur);
+      if (cur && vset.has(cur)) { out = cur; break; }
+    }
+    cache.set(id, out);
+    return out;
+  };
+}
+
+/* Hub threshold, adaptive: on a small graph nothing should fold, on a large one
+   a handful of nodes carry most of the clutter. In deep_research 10 nodes own
+   23% of all edge endpoints — folding them alone removes ~48% of the lines. */
+const HUB_MIN = 14;
+let hubDegree = new Map();     // visible-node id -> degree within the current view
+let foldedCount = 0;           // edges hidden by folding, for the UI to report
+
+function computeDegrees(edges) {
+  const d = new Map();
+  for (const e of edges) {
+    d.set(e.source, (d.get(e.source) || 0) + 1);
+    d.set(e.target, (d.get(e.target) || 0) + 1);
+  }
+  return d;
+}
+
+function isFoldedHub(id) {
+  if (!S.foldHubs || S.expanded.has(id)) return false;
+  return (hubDegree.get(id) || 0) >= HUB_MIN;
+}
+
+function rebuild() {
+  VN = visibleNodes();
+  const vset = new Set(VN.map(n => n.id));
+  const lift = liftMap(vset);
+  const seen = new Map();
+  for (const e of EDGES) {
+    if (e.type === "contains") continue;
+    if (e.type === "imports"    && !S.imports) continue;
+    if (e.type === "calls"      && !S.calls)   continue;
+    if (e.type === "depends_on" && !S.ext)     continue;
+    const s = lift(e.source), t = lift(e.target);
+    if (!s || !t || s === t) continue;
+    const key = s + ">" + t + ">" + e.type;
+    const prev = seen.get(key);
+    if (prev) { prev.w++; continue; }
+    seen.set(key, { source:s, target:t, type:e.type, w:1 });
+  }
+  let edges = [...seen.values()];
+
+  // Degrees must be measured BEFORE folding, or folding changes its own input.
+  hubDegree = computeDegrees(edges);
+
+  const before = edges.length;
+
+  // Neighbourhood mode is already the strongest declutter, so it runs INSTEAD of
+  // folding — otherwise selecting a hub folds away the very edges you asked for.
+  if (S.neighborhood && S.selected) {
+    // Cap the fan-in of an extreme hub: state_manager.py has 76 importers, and
+    // drawing all of them is the same hairball at a smaller scale. Keep the most
+    // important neighbours — the inspector still lists every one of them.
+    const HOOD_MAX = 26;
+    const incident = edges.filter(e => e.source === S.selected || e.target === S.selected);
+    const ranked = incident
+      .map(e => {
+        const other = e.source === S.selected ? e.target : e.source;
+        return { other, imp: (byId.get(other) || {}).importance || 0 };
+      })
+      .sort((a, b) => b.imp - a.imp);
+    const keep = new Set([S.selected]);
+    for (const r of ranked) {
+      if (keep.size > HOOD_MAX) break;
+      keep.add(r.other);
+    }
+    edges = edges.filter(e => keep.has(e.source) && keep.has(e.target));
+    VN = VN.filter(n => keep.has(n.id));
+  } else if (S.foldHubs) {
+    edges = edges.filter(e => !isFoldedHub(e.source) && !isFoldedHub(e.target));
+  }
+  foldedCount = before - edges.length;
+  VE = edges;
+  refreshStats();
+  layout();
+  buildPackets();
+  document.getElementById("empty").style.display = VN.length ? "none" : "grid";
+}
+
+/* ------------------------------------------------------------------ layout
+   Layered by architecture (entry -> ui -> api -> service -> data -> util),
+   force-relaxed inside each band. Deterministic: seeded by node id hash. */
+const BAND_ORDER = ["entry","ui","api","service","data","util","config","infra","test","docs","other","external"];
+
+function hash(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return (h >>> 0) / 4294967295;
+}
+
+/* Indented-tree layout for hierarchy mode. Layer bands answer "what kind of code
+   is this"; a tree answers "what contains what" — and while walking down from the
+   root, containment is the question the reader is actually asking. */
+function layoutTree() {
+  const ROW = 30, INDENT = 44;
+  let y = 0;
+  const vis = new Set(VN.map(n => n.id));
+
+  const walk = (id, depth) => {
+    const n = byId.get(id);
+    if (!n) return;
+    n.x = depth * INDENT;
+    n.y = y;
+    n.r = radius(n);
+    y += ROW + Math.max(0, n.r - 8);
+    const kidMods = (MOD_KIDS.get(id) || []).filter(k => vis.has(k))
+      .sort((a, b) => (byId.get(b).loc || 0) - (byId.get(a).loc || 0));
+    for (const k of kidMods) walk(k, depth + 1);
+    const kidFiles = (MOD_FILES.get(id) || []).filter(f => vis.has(f))
+      .sort((a, b) => (byId.get(b).importance || 0) - (byId.get(a).importance || 0));
+    for (const f of kidFiles) {
+      walk(f, depth + 1);
+      for (const s of (childrenOf.get(f) || [])) if (vis.has(s)) walk(s, depth + 2);
+    }
+  };
+  if (vis.has(ROOT_MOD)) walk(ROOT_MOD, 0);
+
+  // Externals hang to the side rather than pretending to be part of the tree.
+  let ey = 0;
+  for (const n of VN) {
+    if (n.type === "external") { n.x = -INDENT * 2.4; n.y = ey; n.r = radius(n); ey += 26; }
+  }
+  BANDS = [];                       // a tree has no layer bands
+  treeHeight = y;
+  frameTree();
+}
+
+let treeHeight = 0;
+
+/* A tree is tall and narrow. Scale to fit its HEIGHT (never below a legible
+   floor) and anchor left — fitting both axes would squash it into a column, and
+   a fixed scale=1 pushed most rows off-screen on a 350-file repo. */
+function frameTree() {
+  const availH = innerHeight - 150, availW = innerWidth - 300 - 360;
+  let sc = treeHeight > 0 ? availH / treeHeight : 1;
+  sc = Math.max(0.28, Math.min(1, sc));      // below ~0.28 text is unreadable
+  S.scale = sc;
+  S.tx = 268;
+  S.ty = 96;
+  // If the tree still overflows, the reader scrolls (drag) — same as an editor.
+}
+
+function layout() {
+  if (S.hier) { layoutTree(); return; }
+  const bands = new Map();
+  for (const n of VN) {
+    const b = n.layer || "other";
+    bucket(bands, b).push(n);
+  }
+  const active = BAND_ORDER.filter(b => bands.has(b));
+  const W = Math.max(1000, Math.min(2100, 260 * Math.ceil(Math.sqrt(VN.length))));
+  const ROW = 76;          // vertical pitch inside a band
+  const GAP = 132;         // breathing room + headroom for the band heading
+
+  // Bands stack with content-aware height so sparse layers leave no dead space.
+  BANDS = [];
+  let cursor = 0;
+  active.forEach(band => {
+    const list = bands.get(band);
+    // Group by owning folder so related files sit together instead of scattering.
+    const groups = new Map();
+    for (const n of list) {
+      const g = n.type === "module" ? "\u0000modules"
+              : n.type === "external" ? "\u0000external"
+              : (n.module || n.filePath || "").replace(/^mod:/, "");
+      bucket(groups, g).push(n);
+    }
+    const ordered = [...groups.entries()].sort((a, b) => b[1].length - a[1].length);
+    const perRow = Math.max(5, Math.ceil(Math.sqrt(list.length * 2.6)));
+    const top = cursor;
+    let col = 0, row = 0;
+    for (const [, members] of ordered) {
+      members.sort((a, b) => (b.importance || b.loc || 0) - (a.importance || a.loc || 0));
+      // Keep a folder's files contiguous; wrap to a new row if it can't fit.
+      if (col > 0 && col + members.length > perRow && members.length <= perRow) {
+        col = 0; row++;
+      }
+      for (const n of members) {
+        const jx = (hash(n.id) - 0.5) * 26, jy = (hash(n.id + "y") - 0.5) * 20;
+        n.x = (col - (perRow - 1) / 2) * (W / perRow) + jx;
+        n.y = top + row * ROW + jy;
+        n.r = radius(n);
+        col++;
+        if (col >= perRow) { col = 0; row++; }
+      }
+      col++;                                  // one empty slot between folders
+      if (col >= perRow) { col = 0; row++; }
+    }
+    const height = row * ROW;
+    BANDS.push({ id: band, top: top, bottom: top + height, count: list.length });
+    cursor = top + height + GAP;
+  });
+
+  // Remember each node's home band, then relax without letting bands bleed.
+  const homeBand = new Map(BANDS.map(b => [b.id, b]));
+  for (const n of VN) n._band = homeBand.get(n.layer || "other");
+  relax();
+  // Clamp back into the owning band so headings never overlap another layer.
+  for (const n of VN) {
+    const b = n._band;
+    if (!b) continue;
+    const lo = b.top - ROW * 0.45, hi = b.bottom + ROW * 0.45;
+    if (n.y < lo) n.y = lo;
+    else if (n.y > hi) n.y = hi;
+  }
+
+  // Recompute extents from final positions so headings sit right above content.
+  for (const b of BANDS) { b._t = Infinity; b._b = -Infinity; }
+  for (const n of VN) {
+    const b = n._band;
+    if (!b) continue;
+    if (n.y - n.r < b._t) b._t = n.y - n.r;
+    if (n.y + n.r > b._b) b._b = n.y + n.r;
+  }
+  for (const b of BANDS) {
+    if (Number.isFinite(b._t)) { b.top = b._t; b.bottom = b._b; }
+  }
+  BANDS = BANDS.filter(b => Number.isFinite(b._t));
+  fit(false);
+}
+
+/* Overlap relaxation via a uniform spatial hash: only nearby pairs are compared,
+   which keeps big graphs (thousands of symbols) interactive instead of O(n^2). */
+function relax() {
+  const n = VN.length;
+  if (n < 2) return;
+  let maxR = 0;
+  for (const v of VN) if (v.r > maxR) maxR = v.r;
+  const cell = Math.max(24, maxR * 2 + 14);
+  const passes = n > 1800 ? 4 : n > 700 ? 8 : 18;
+  const grid = new Map();
+  const key = (cx, cy) => cx + "," + cy;
+
+  for (let pass = 0; pass < passes; pass++) {
+    grid.clear();
+    for (const v of VN) {
+      const k = key(Math.floor(v.x / cell), Math.floor(v.y / cell));
+      let b = grid.get(k);
+      if (!b) { b = []; grid.set(k, b); }
+      b.push(v);
+    }
+    let moved = 0;
+    for (const [k, bucketNodes] of grid) {
+      const [cx, cy] = k.split(",").map(Number);
+      const near = [];
+      for (let ox = -1; ox <= 1; ox++)
+        for (let oy = -1; oy <= 1; oy++) {
+          const nb = grid.get(key(cx + ox, cy + oy));
+          if (nb) near.push(nb);
+        }
+      for (const a of bucketNodes) {
+        for (const group of near) {
+          for (const b of group) {
+            if (a === b) continue;
+            let dx = b.x - a.x, dy = b.y - a.y;
+            const need = a.r + b.r + 12;
+            const d2 = dx*dx + dy*dy;
+            if (d2 > need*need) continue;
+            let d = Math.sqrt(d2);
+            if (d < 0.01) {           // exact overlap: nudge deterministically
+              dx = (hash(a.id) - 0.5) || 0.5; dy = (hash(b.id) - 0.5) || 0.5; d = 1;
+            }
+            const push = (need - d) / 2;
+            dx /= d; dy /= d;
+            a.x -= dx*push; a.y -= dy*push*0.5;
+            b.x += dx*push; b.y += dy*push*0.5;
+            moved++;
+          }
+        }
+      }
+    }
+    if (!moved) break;   // settled early
+  }
+}
+
+function radius(n) {
+  if (n.type === "module") return 11 + Math.min(17, Math.sqrt(n.fileCount || 1) * 3.4);
+  if (n.type === "external") return 6 + Math.min(9, Math.sqrt(n.usedBy || 1) * 1.7);
+  const base = 5.5 + Math.sqrt(Math.max(n.loc || 8, 4)) * 0.72;
+  return Math.min(25, base + (n.importance || 0) * 8);
+}
+
+/* ------------------------------------------------------------------ canvas */
+const cv = document.getElementById("cv"), ctx = cv.getContext("2d");
+const fx = document.getElementById("fx"), fctx = fx.getContext("2d");
+let DPR = 1;
+function resize() {
+  DPR = Math.min(2, window.devicePixelRatio || 1);
+  for (const c of [cv, fx]) { c.width = innerWidth * DPR; c.height = innerHeight * DPR; }
+  ctx.setTransform(DPR,0,0,DPR,0,0);
+  fctx.setTransform(DPR,0,0,DPR,0,0);
+  buildStars();
+  if (SM && S.mode === "star") { skyResize(); drawSky(); }
+  draw();
+}
+addEventListener("resize", resize);
+
+function fit(redraw = true) {
+  if (!VN.length) return;
+  // In tree mode "fit" means "back to the top of the tree", not "squash both axes".
+  if (S.hier) {
+    frameTree();
+    if (redraw) draw();
+    return;
+  }
+  let x0=1e9,y0=1e9,x1=-1e9,y1=-1e9;
+  for (const n of VN) {
+    x0=Math.min(x0,n.x-n.r); x1=Math.max(x1,n.x+n.r);
+    y0=Math.min(y0,n.y-n.r); y1=Math.max(y1,n.y+n.r);
+  }
+  const padL = 240, padR = 350, padT = 82, padB = 96;
+  const w = x1-x0 || 1, h = y1-y0 || 1;
+  S.scale = Math.max(0.09, Math.min(2.4,
+    Math.min((innerWidth-padL-padR)/w, (innerHeight-padT-padB)/h)));
+  S.tx = padL + (innerWidth-padL-padR)/2 - (x0+x1)/2*S.scale;
+  S.ty = padT + (innerHeight-padT-padB)/2 - (y0+y1)/2*S.scale;
+  if (redraw) draw();
+}
+
+// hot = the colour used when the edge is in the focused neighbourhood.
+// label = what the relationship is called, in words, on the canvas.
+const EDGE_STYLE = {
+  imports:    { color:"#5b6c8f", hot:"#8ec8ff", dash:[7,5],  label:"imports" },
+  calls:      { color:"#8b6fd4", hot:"#c98cff", dash:[4,3],  label:"calls" },
+  depends_on: { color:"#475569", hot:"#94a3b8", dash:[2,4],  label:"depends on" },
+  inherits:   { color:"#34d399", hot:"#4ade80", dash:[6,3],  label:"inherits" },
+  contains:   { color:"#3a4560", hot:"#64748b", dash:[1,4],  label:"contains" },
+};
+
+/** The one true edge curve. Both canvases use it so dots ride the drawn line. */
+function edgeMid(a, b) {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 + Math.abs(b.x - a.x) * 0.055 };
+}
+function strokeEdge(c, a, b) {
+  const m = edgeMid(a, b);
+  c.beginPath();
+  c.moveTo(a.x, a.y);
+  c.quadraticCurveTo(m.x, m.y, b.x, b.y);
+  c.stroke();
+}
+function arrowHead(c, a, b, color) {
+  const m = edgeMid(a, b);
+  const ang = Math.atan2(b.y - m.y, b.x - m.x), h = 6 / S.scale;
+  const ex = b.x - Math.cos(ang) * b.r, ey = b.y - Math.sin(ang) * b.r;
+  const dash = c.getLineDash();
+  c.setLineDash([]);
+  c.beginPath();
+  c.moveTo(ex, ey);
+  c.lineTo(ex - Math.cos(ang - 0.4) * h, ey - Math.sin(ang - 0.4) * h);
+  c.lineTo(ex - Math.cos(ang + 0.4) * h, ey - Math.sin(ang + 0.4) * h);
+  c.closePath();
+  c.fillStyle = color;
+  c.fill();
+  c.setLineDash(dash);
+}
+
+/**
+ * Flowing edges + their relationship names, painted on the OVERLAY canvas.
+ * Only the focused node's own edges animate, so this stays cheap no matter how
+ * large the graph is — the expensive full-graph pass never repeats.
+ */
+const LIVE_EDGE_CAP = 140;   // frame budget: a 190-degree hub would cost ~36ms
+
+function liveEdgesFor(focus) {
+  // Only edges INCIDENT to the focus animate. Using the full neighbour set would
+  // also catch neighbour-to-neighbour links — 1341 edges on a hub like
+  // sqlalchemy's __init__.py, which blows the frame budget for no clarity gain.
+  const out = [];
+  for (const e of VE) {
+    if (e.source !== focus && e.target !== focus) continue;
+    const a = byId.get(e.source), b = byId.get(e.target);
+    if (!a || !b || a.x === undefined || b.x === undefined) continue;
+    out.push(e);
+    if (out.length >= LIVE_EDGE_CAP) break;
+  }
+  return out;
+}
+
+function drawLiveEdges(light) {
+  const focus = S.selected || S.hover;
+  if (!focus) return;
+  fctx.save();
+  fctx.translate(S.tx, S.ty);
+  fctx.scale(S.scale, S.scale);
+
+  const labels = [];
+  for (const e of liveEdgesFor(focus)) {
+    const a = byId.get(e.source), b = byId.get(e.target);
+    const st = EDGE_STYLE[e.type] || EDGE_STYLE.imports;
+    const outgoing = e.source === focus;
+    fctx.globalAlpha = 0.95;
+    fctx.strokeStyle = st.hot || st.color;
+    fctx.lineWidth = Math.max(0.5, 1.6 / S.scale);
+    fctx.setLineDash((st.dash || [7, 5]).map(v => v / S.scale));
+    // Dashes crawl toward the target, so direction is visible at a glance.
+    fctx.lineDashOffset = -(M.t * (outgoing ? 30 : 18)) / S.scale;
+    strokeEdge(fctx, a, b);
+    if (S.scale > 0.35) arrowHead(fctx, a, b, st.hot || st.color);
+    const m = edgeMid(a, b);
+    labels.push({ st, x: m.x, y: m.y, type: e.type });
+  }
+  fctx.setLineDash([]); fctx.lineDashOffset = 0; fctx.globalAlpha = 1;
+  drawEdgeLabels(labels, light, fctx);
+  fctx.restore();
+}
+
+/** Draw relationship names at edge midpoints, skipping any that would collide. */
+function drawEdgeLabels(items, light, c) {
+  if (!items.length || S.scale < 0.42) return;
+  const fs = Math.min(9.5 / S.scale, 30);
+  c.font = fs + "px ui-monospace,'SF Mono',Menlo,monospace";
+  c.textAlign = "center";
+  c.textBaseline = "middle";
+  const taken = [];
+  for (const it of items.slice(0, 24)) {
+    const text = it.st.label || it.type;
+    const w = text.length * fs * 0.58, h = fs * 1.5;
+    const box = [it.x - w/2, it.y - h/2, it.x + w/2, it.y + h/2];
+    let clash = false;
+    for (const t of taken) {
+      if (box[0] < t[2] && box[2] > t[0] && box[1] < t[3] && box[3] > t[1]) { clash = true; break; }
+    }
+    if (clash) continue;
+    taken.push(box);
+    // Plate behind the text so it stays readable over lines and glow.
+    c.fillStyle = light ? "rgba(255,255,255,.9)" : "rgba(5,8,18,.88)";
+    const r = Math.min(4 / S.scale, h / 2);
+    c.beginPath();
+    if (c.roundRect) c.roundRect(box[0] - 3/S.scale, box[1], w + 6/S.scale, h, r);
+    else c.rect(box[0] - 3/S.scale, box[1], w + 6/S.scale, h);
+    c.fill();
+    c.fillStyle = it.st.hot || it.st.color;
+    c.fillText(text, it.x, it.y);
+  }
+  c.textBaseline = "alphabetic";
+}
+
+function matches(n) {
+  if (!S.query) return false;
+  const q = S.query.toLowerCase();
+  return (n.name||"").toLowerCase().includes(q)
+      || (n.filePath||"").toLowerCase().includes(q)
+      || (n.summary||"").toLowerCase().includes(q)
+      || (n.tags||[]).some(t => t.toLowerCase().includes(q));
+}
+
+function neighborsOf(id) {
+  const set = new Set([id]);
+  for (const e of VE) {
+    if (e.source === id) set.add(e.target);
+    if (e.target === id) set.add(e.source);
+  }
+  return set;
+}
+
+function draw() {
+  const light = document.documentElement.dataset.theme === "light";
+  ctx.save();
+  ctx.fillStyle = light ? "#f6f7f9" : "#0b0f17";
+  ctx.fillRect(0,0,innerWidth,innerHeight);
+  ctx.translate(S.tx, S.ty); ctx.scale(S.scale, S.scale);
+
+  // Only treat a selection as "focus" when it is actually on screen. Selecting a
+  // node that later got collapsed away used to dim EVERYTHING, silently killing
+  // every label in the view.
+  const visSet = new Set(VN.map(n => n.id));
+  const focusRaw = S.selected || S.hover;
+  const focus = (focusRaw && visSet.has(focusRaw)) ? focusRaw : null;
+  const near = focus ? neighborsOf(focus) : null;
+  const tourNodes = currentTourNodes();
+
+  /* band separators + headings, drawn in world space so they track the graph */
+  let bx0 = 1e9, bx1 = -1e9;
+  for (const n of VN) { bx0 = Math.min(bx0, n.x - n.r); bx1 = Math.max(bx1, n.x + n.r); }
+  if (BANDS.length && bx1 > bx0) {
+    const pad = 26;
+    const head = 22 / S.scale;         // headroom for the heading, zoom-invariant
+    for (const b of BANDS) {
+      const col = layerColor(b.id);
+      ctx.globalAlpha = 0.07;
+      ctx.fillStyle = col;
+      ctx.fillRect(bx0 - pad, b.top - head - 6/S.scale,
+                   (bx1 - bx0) + pad*2, (b.bottom - b.top) + head + 18/S.scale);
+      ctx.globalAlpha = 0.9;
+      ctx.fillStyle = col;
+      ctx.textAlign = "left";
+      ctx.font = "700 " + (11.5/S.scale) + "px ui-sans-serif,system-ui,sans-serif";
+      ctx.fillText((LAYER_NAMES[b.id] || b.id).toUpperCase() + "  ·  " + b.count,
+                   bx0 - pad + 5/S.scale, b.top - head + 4/S.scale);
+      ctx.globalAlpha = 1;
+    }
+  }
+
+  /* edges. The animated ones (focused neighbourhood) are NOT drawn here — they
+     move to the overlay so this expensive full-graph pass stays a one-off. */
+  // Distance LOD, borrowed from Physics-atlas' uReveal: zoomed far out the lines
+  // become noise, so they fade and let the layer bands carry the structure.
+  const reveal = focus ? 1 : Math.max(0, Math.min(1, (S.scale - 0.16) / 0.34));
+  const animated = focus && !REDUCED && M.on;
+  // Exactly the set the overlay will animate, so nothing is drawn twice or lost.
+  const liveSet = animated ? new Set(liveEdgesFor(focus)) : null;
+  for (const e of VE) {
+    const a = byId.get(e.source), b = byId.get(e.target);
+    if (!a || !b || a.x === undefined || b.x === undefined) continue;
+    const on = !focus || (near.has(e.source) && near.has(e.target));
+    if (liveSet && liveSet.has(e)) continue;   // overlay owns this one
+    const st = EDGE_STYLE[e.type] || EDGE_STYLE.imports;
+    ctx.globalAlpha = (on ? (focus ? 0.9 : 0.3) : 0.05) * (on && focus ? 1 : reveal);
+    if (ctx.globalAlpha < 0.012) continue;      // invisible: skip the stroke cost
+    ctx.strokeStyle = on && focus ? (st.hot || st.color) : st.color;
+    ctx.lineWidth = Math.max(0.4, 0.85 / S.scale);
+    ctx.setLineDash((st.dash || [7, 5]).map(v => v / S.scale));
+    ctx.lineDashOffset = 0;
+    strokeEdge(ctx, a, b);
+    if (focus && on && S.scale > 0.35) arrowHead(ctx, a, b, st.hot || st.color);
+  }
+  ctx.setLineDash([]); ctx.lineDashOffset = 0; ctx.globalAlpha = 1;
+
+  /* nodes — draw order puts important nodes last so their labels win */
+  // Always label something: collision detection already prevents overlap, so a
+  // low zoom simply yields fewer, larger, still-legible labels.
+  // Budget scales with zoom AND shrinks on crowded views: at 0.5x a 230-node
+  // graph cannot carry 200 labels without them colliding into mush.
+  const crowd = VN.length > 150 ? 0.45 : VN.length > 60 ? 0.7 : 1;
+  // Tree mode: one row per node with no overlap by construction, so every node
+  // must be labelled — a file tree with unnamed rows is useless.
+  const labelBudget = S.hier ? 4000
+    : Math.round((S.scale > 1.1 ? 400 : S.scale > 0.6 ? 200 : 90) * crowd);
+  const canLabel = true;
+  // Labels sit above the glow, so they get a dark halo of their own (three-layer
+  // shadow, same trick the atlas uses to keep star names legible over nebulae).
+  const labelHalo = light ? "rgba(255,255,255,.95)" : "rgba(3,4,10,.95)";
+  const claimed = [];   // occupied label boxes, world space
+  // Tree mode keeps document order (top-to-bottom); band mode labels the most
+  // important nodes first because collision detection drops the rest.
+  const ranked = !canLabel ? VN
+    : S.hier ? [...VN].sort((a, b) => a.y - b.y)
+    : [...VN].sort((a, b) => (b.importance || b.loc || 0) - (a.importance || a.loc || 0));
+  let labelsDrawn = 0;
+  for (const n of VN) {
+    if (n.x === undefined) continue;
+    const col = layerColor(n.layer);
+    const isMatch = matches(n);
+    const dim = (focus && !near.has(n.id)) || (S.query && !isMatch);
+    const inTour = tourNodes.has(n.id);
+
+    ctx.globalAlpha = dim ? 0.22 : 1;
+
+    if (S.cycles && cycleSet.has(n.id)) {
+      ctx.beginPath(); ctx.arc(n.x,n.y,n.r+6,0,7); 
+      ctx.strokeStyle="#f87171"; ctx.lineWidth=2/S.scale; ctx.stroke();
+    }
+    if (S.entries && n.isEntry) {
+      ctx.beginPath(); ctx.arc(n.x,n.y,n.r+4,0,7);
+      ctx.strokeStyle="#fbbf24"; ctx.lineWidth=2/S.scale; ctx.stroke();
+    }
+    if (isMatch || inTour) {
+      ctx.beginPath(); ctx.arc(n.x,n.y,n.r+8,0,7);
+      ctx.fillStyle = inTour ? "#38bdf83a" : "#fbbf243a"; ctx.fill();
+    }
+
+    ctx.beginPath();
+    if (n.type === "module") {
+      const r = n.r;
+      ctx.roundRect ? ctx.roundRect(n.x-r, n.y-r*0.8, r*2, r*1.6, 5)
+                    : ctx.rect(n.x-r, n.y-r*0.8, r*2, r*1.6);
+    } else if (n.type === "external") {
+      ctx.moveTo(n.x, n.y-n.r); ctx.lineTo(n.x+n.r, n.y);
+      ctx.lineTo(n.x, n.y+n.r); ctx.lineTo(n.x-n.r, n.y); ctx.closePath();
+    } else {
+      ctx.arc(n.x, n.y, n.r, 0, 7);
+    }
+    ctx.fillStyle = col; ctx.fill();
+
+    if (n.id === S.selected) {
+      ctx.strokeStyle = "#fff"; ctx.lineWidth = 2.4/S.scale; ctx.stroke();
+    } else if (n.summary) {   /* enriched nodes get a subtle ring */
+      ctx.strokeStyle = "#ffffff55"; ctx.lineWidth = 1/S.scale; ctx.stroke();
+    }
+
+    // Collapsed level advertises how much is inside — the click affordance.
+    const hidden = S.hier ? hiddenChildCount(n) : 0;
+    if (hidden && S.scale > 0.3) {
+      const fs = Math.min(9 / S.scale, 24);
+      ctx.font = "600 " + fs + "px ui-monospace,'SF Mono',Menlo,monospace";
+      ctx.textAlign = "center";
+      const txt = "+" + hidden;
+      const w = txt.length * fs * 0.66;
+      const bx = n.x + n.r + w * 0.62, by = n.y - n.r * 0.55;
+      ctx.fillStyle = light ? "rgba(255,255,255,.94)" : "rgba(8,12,24,.92)";
+      ctx.beginPath();
+      if (ctx.roundRect) ctx.roundRect(bx - w/2, by - fs*0.72, w, fs*1.4, fs*0.7);
+      else ctx.rect(bx - w/2, by - fs*0.72, w, fs*1.4);
+      ctx.fill();
+      ctx.strokeStyle = col; ctx.lineWidth = 0.9/S.scale; ctx.stroke();
+      ctx.fillStyle = col;
+      ctx.fillText(txt, bx, by + fs*0.28);
+    }
+
+    // A folded hub advertises what it is hiding, so nothing disappears silently.
+    if (isFoldedHub(n.id) && S.scale > 0.34) {
+      const deg = hubDegree.get(n.id) || 0;
+      const fs = Math.min(8.5 / S.scale, 22);
+      ctx.font = "600 " + fs + "px ui-monospace,'SF Mono',Menlo,monospace";
+      ctx.textAlign = "center";
+      const txt = "⋯" + deg;
+      const w = txt.length * fs * 0.62;
+      const bx = n.x, by = n.y - n.r - fs * 0.95;
+      ctx.fillStyle = light ? "rgba(255,255,255,.92)" : "rgba(8,12,24,.9)";
+      ctx.beginPath();
+      if (ctx.roundRect) ctx.roundRect(bx - w/2, by - fs*0.75, w, fs*1.45, fs*0.5);
+      else ctx.rect(bx - w/2, by - fs*0.75, w, fs*1.45);
+      ctx.fill();
+      ctx.strokeStyle = col; ctx.lineWidth = 0.8/S.scale; ctx.stroke();
+      ctx.fillStyle = col;
+      ctx.fillText(txt, bx, by + fs*0.25);
+    }
+
+  }
+
+  /* labels: collision-avoided, importance-first, so dense graphs stay readable */
+  if (canLabel) {
+    ctx.textAlign = "center";
+    ctx.globalAlpha = 1;      // node loop may have left this dimmed
+    // Target a constant ~11.5px on screen regardless of zoom, so labels stay legible.
+    const fs = Math.min(11.5 / S.scale, 46);
+    const pad = 3 / S.scale;
+    for (const n of ranked) {
+      if (n.x === undefined) continue;
+      if (labelsDrawn >= labelBudget && n.id !== S.selected) continue;
+      const dim = (focus && !near.has(n.id)) || (S.query && !matches(n));
+      if (dim && n.id !== S.selected) continue;
+      const label = n.name.length > 26 ? n.name.slice(0,25)+"…" : n.name;
+      // Pad the claimed box so neighbouring labels keep visible air between them.
+      const w = label.length * fs * 0.52 + fs * 0.9, h = fs * 1.5;
+      // Tree mode: label sits to the RIGHT of the dot, so indentation reads as
+      // hierarchy. Band mode keeps labels centred beneath the node.
+      const tree = S.hier;
+      const cx = tree ? n.x + n.r + 6/S.scale + w/2 : n.x;
+      const cy = tree ? n.y + fs * 0.34 : n.y + n.r + 11/S.scale;
+      const box = [cx - w/2 - pad, cy - h, cx + w/2 + pad, cy + pad];
+      let clash = false;
+      // Tree rows are laid out non-overlapping already; running collision here
+      // would drop labels for no reason (long paths sit under short siblings).
+      if (!S.hier) {
+        for (const c of claimed) {
+          if (box[0] < c[2] && box[2] > c[0] && box[1] < c[3] && box[3] > c[1]) { clash = true; break; }
+        }
+      }
+      if (clash && n.id !== S.selected) continue;
+      claimed.push(box);
+      labelsDrawn++;
+      ctx.font = (n.type === "module" ? "650 " : "") + fs +
+                 "px ui-sans-serif,system-ui,sans-serif";
+      // Contrasting outline first so glyphs read against halos and bright edges.
+      // Stroke must scale with the FONT (fs), not the world, or it drowns the glyph.
+      ctx.lineWidth = fs * 0.30;
+      ctx.strokeStyle = labelHalo;
+      ctx.lineJoin = "round";
+      ctx.strokeText(label, cx, cy);
+      // Light theme needs near-black ink; the pale halo above would erase mid-greys.
+      ctx.fillStyle = light ? "#0b1020" : "#f2f5ff";
+      ctx.fillText(label, cx, cy);
+    }
+  }
+  ctx.globalAlpha = 1;
+  ctx.restore();
+}
+
+/* ==================================================================== MOTION
+   Layered like a deep-field exposure:
+     1. starfield   — parallax dust, twinkling via sin(phase)
+     2. packets     — comet dots travelling source->target along each edge,
+                      with an exponential trail: intensity = exp(-k * distBehind)
+     3. halos       — breathing rings on entry points and the selected node
+   Everything lives on the #fx overlay so the static graph is never repainted.
+   Honors prefers-reduced-motion and the ⏸ button. */
+
+const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
+const M = {
+  on: !REDUCED,
+  t: 0,               // seconds
+  stars: [],
+  packets: [],
+  lastFrame: 0,
+  fps: 60,
+};
+
+/* ---- starfield: screen-space, cheap, subtly parallaxed by pan ---- */
+function buildStars() {
+  const count = Math.round(Math.min(190, (innerWidth * innerHeight) / 11000));
+  M.stars = [];
+  for (let i = 0; i < count; i++) {
+    const h = hash("star" + i), h2 = hash("star2" + i), h3 = hash("star3" + i);
+    M.stars.push({
+      x: h * innerWidth, y: h2 * innerHeight,
+      r: 0.4 + h3 * 1.25,
+      phase: h * 6.283, speed: 0.35 + h2 * 1.1,
+      depth: 0.03 + h3 * 0.09,          // parallax factor against pan
+      warm: h3 > 0.82,                   // a few warm dust motes
+    });
+  }
+}
+
+function drawStars(light) {
+  if (light) return;                     // the paper theme stays clean
+  const ox = S.tx, oy = S.ty;
+  // Keep dust off the glass panels so the chrome stays crisp.
+  const railR = 236, infoL = innerWidth - 346, topB = 58;
+  for (const s of M.stars) {
+    // exp-shaped twinkle, same shape the atlas uses in its star shader
+    const tw = 0.62 + 0.38 * Math.sin(M.t * s.speed + s.phase);
+    let x = (s.x + ox * s.depth) % innerWidth; if (x < 0) x += innerWidth;
+    let y = (s.y + oy * s.depth) % innerHeight; if (y < 0) y += innerHeight;
+    if (y > topB && (x < railR || (S.selected && x > infoL))) continue;
+    const a = tw * 0.5;
+    fctx.beginPath();
+    fctx.arc(x, y, s.r, 0, 7);
+    fctx.fillStyle = s.warm ? "rgba(201,138,75," + a + ")"
+                            : "rgba(190,210,255," + a + ")";
+    fctx.fill();
+    if (s.r > 1.25) {                    // brightest few get a soft bloom
+      const g = fctx.createRadialGradient(x, y, 0, x, y, s.r * 7);
+      g.addColorStop(0, "rgba(190,215,255," + (a * 0.3) + ")");
+      g.addColorStop(1, "rgba(190,215,255,0)");
+      fctx.fillStyle = g;
+      fctx.beginPath(); fctx.arc(x, y, s.r * 7, 0, 7); fctx.fill();
+    }
+  }
+}
+
+/* ---- packets: one travelling dot per interesting edge ---- */
+const PACKET_CAP = 190;          // hard ceiling: keeps 60fps on huge graphs
+
+function buildPackets() {
+  M.packets = [];
+  if (!VE.length) return;
+  // Prefer edges the reader is most likely to care about: the current focus,
+  // then the tour path, then the heaviest imports.
+  const focus = S.selected;
+  const tourIds = currentTourNodes();
+  const scored = VE.map(e => {
+    let w = 0;
+    const a = byId.get(e.source), b = byId.get(e.target);
+    if (!a || !b || a.x === undefined || b.x === undefined) return null;
+    if (e.type === "imports") w += 2;
+    if (e.type === "calls") w += 1.5;
+    if (focus && (e.source === focus || e.target === focus)) w += 40;
+    if (tourIds.has(e.source) && tourIds.has(e.target)) w += 30;
+    w += (a.importance || 0) + (b.importance || 0);
+    return { e, w, a, b };
+  }).filter(Boolean).sort((p, q) => q.w - p.w).slice(0, PACKET_CAP);
+
+  for (const { e, a, b } of scored) {
+    const seed = hash(e.source + ">" + e.target);
+    const dist = Math.hypot(b.x - a.x, b.y - a.y);
+    M.packets.push({
+      a, b, type: e.type,
+      // Deterministic offset so the field looks organic but is reproducible.
+      p: seed,
+      speed: (0.09 + hash("s" + e.source + e.target) * 0.07) * (260 / Math.max(dist, 90)),
+    });
+  }
+}
+
+function edgePoint(pk, t) {
+  // Mirror the static renderer's quadratic curve so dots ride their own line.
+  const { a, b } = pk;
+  const mx = (a.x + b.x) / 2, my = (a.y + b.y) / 2 + Math.abs(b.x - a.x) * 0.055;
+  const u = 1 - t;
+  return {
+    x: u*u*a.x + 2*u*t*mx + t*t*b.x,
+    y: u*u*a.y + 2*u*t*my + t*t*b.y,
+  };
+}
+
+function drawPackets(light) {
+  const focus = S.selected || S.hover;
+  const near = focus ? neighborsOf(focus) : null;
+  const tourIds = currentTourNodes();
+  const TRAIL = 7;                          // samples behind the head
+
+  for (const pk of M.packets) {
+    const hot = tourIds.has(pk.a.id) && tourIds.has(pk.b.id);
+    const onFocus = focus && near.has(pk.a.id) && near.has(pk.b.id);
+    // When something is focused, unrelated traffic fades out of the way.
+    let strength = focus ? (onFocus ? 1 : 0.06) : 0.5;
+    if (hot) strength = 1;
+    if (strength < 0.08) continue;
+
+    const col = hot ? "255,217,138"
+              : pk.type === "calls" ? "201,140,255"
+              : light ? "37,99,235" : "142,200,255";
+
+    for (let i = TRAIL; i >= 0; i--) {
+      const t = pk.p - i * 0.021;
+      if (t < 0 || t > 1) continue;
+      const pt = edgePoint(pk, t);
+      // Exponential falloff behind the head — the comet-trail look.
+      const fall = Math.exp(-i * 0.42);
+      const a = fall * strength * (light ? 0.5 : 0.72);
+      const r = (i === 0 ? 2.5 : 1.9) * fall + 0.35;
+      if (i === 0) {                        // glowing head
+        const g = fctx.createRadialGradient(pt.x, pt.y, 0, pt.x, pt.y, 13);
+        g.addColorStop(0, "rgba(" + col + "," + (a * 0.85) + ")");
+        g.addColorStop(1, "rgba(" + col + ",0)");
+        fctx.fillStyle = g;
+        fctx.beginPath(); fctx.arc(pt.x, pt.y, 13, 0, 7); fctx.fill();
+      }
+      fctx.beginPath();
+      fctx.arc(pt.x, pt.y, r, 0, 7);
+      fctx.fillStyle = "rgba(" + col + "," + a + ")";
+      fctx.fill();
+    }
+  }
+}
+
+/* ---- halos: breathing rings that mark what matters right now ---- */
+function drawHalos(light) {
+  const tourIds = currentTourNodes();
+  const breathe = 0.5 + 0.5 * Math.sin(M.t * 1.5);
+
+  // On paper the soft bloom is dropped entirely; only the crisp ring remains.
+  const fillA = light ? 0.0 : 1.0, strokeBoost = light ? 1.5 : 1.0;
+  const ring = (n, rgb, base, spread) => {
+    const r = n.r * S.scale;
+    const sx = n.x * S.scale + S.tx, sy = n.y * S.scale + S.ty;
+    if (sx < -60 || sy < -60 || sx > innerWidth + 60 || sy > innerHeight + 60) return;
+    const rad = r + base + breathe * spread;
+    // Ring only — a filled gradient would wash out the label sitting under it.
+    const g = fctx.createRadialGradient(sx, sy, r + 1, sx, sy, rad);
+    g.addColorStop(0, "rgba(" + rgb + ",0)");
+    g.addColorStop(0.5, "rgba(" + rgb + "," + ((0.10 + breathe * 0.10) * fillA) + ")");
+    g.addColorStop(1, "rgba(" + rgb + ",0)");
+    if (fillA) {
+      fctx.fillStyle = g;
+      fctx.beginPath(); fctx.arc(sx, sy, rad, 0, 7);
+      fctx.arc(sx, sy, r + 1, 0, 7, true);        // donut: leave the core clear
+      fctx.fill();
+    }
+    fctx.beginPath(); fctx.arc(sx, sy, rad * 0.8, 0, 7);
+    fctx.strokeStyle = "rgba(" + rgb + "," +
+      Math.min(0.85, (0.14 + breathe * 0.26) * strokeBoost) + ")";
+    fctx.lineWidth = light ? 1.4 : 1;
+    fctx.stroke();
+  };
+
+  for (const n of VN) {
+    if (n.x === undefined) continue;
+    // Light theme needs saturated ink, not glow: on paper a bloom reads as smudge.
+    if (tourIds.has(n.id)) ring(n, light ? "180,83,9" : "255,217,138", 12, 9);
+    else if (S.entries && n.isEntry) ring(n, light ? "190,24,93" : "244,114,182", 9, 7);
+    if (n.id === S.selected) ring(n, light ? "37,99,235" : "142,200,255", 15, 10);
+  }
+}
+
+/* ---- the loop: overlay only, so cost is independent of graph size ---- */
+function frame(now) {
+  requestAnimationFrame(frame);
+  const dt = Math.min(0.05, (now - M.lastFrame) / 1000 || 0.016);
+  M.lastFrame = now;
+
+  fctx.clearRect(0, 0, innerWidth, innerHeight);
+  if (!M.on) return;
+
+  M.t += dt;
+  const light = document.documentElement.dataset.theme === "light";
+  fctx.globalCompositeOperation = light ? "source-over" : "lighter";
+  drawStars(light);
+  for (const pk of M.packets) {
+    pk.p += pk.speed * dt;
+    if (pk.p > 1) pk.p -= 1 + hash("r" + pk.a.id) * 0.35;  // staggered respawn
+  }
+  drawPackets(light);
+  drawHalos(light);
+  fctx.globalCompositeOperation = "source-over";
+
+  // Flowing edges and their relationship labels are drawn here, not on the base
+  // canvas, so animation never triggers a full-graph repaint. Cost is bounded by
+  // the focused node's degree instead of the total node count.
+  if (S.mode === "explore") drawLiveEdges(light);
+  // The star map has its own canvas and its own breathing/twinkle clock.
+  if (S.mode === "star") { SKY.t += dt; skyTick(dt); drawSky(); }
+}
+
+function setMotion(on) {
+  M.on = on;
+  document.getElementById("bMotion").classList.toggle("on", on);
+  document.getElementById("bMotion").textContent = on ? "⏸" : "▶";
+  if (!on) {
+    fctx.clearRect(0, 0, innerWidth, innerHeight);
+    draw();                    // settle the dashes back to a static pattern
+  }
+  // The overview animates via CSS/SMIL, so pause it at the document level too.
+  const ov = document.getElementById("ov");
+  ov.style.setProperty("--play", on ? "running" : "paused");
+  ov.classList.toggle("paused", !on);
+  const svg = document.getElementById("ovSvg");
+  if (svg) { try { on ? svg.unpauseAnimations() : svg.pauseAnimations(); } catch (e) {} }
+}
+
+/* ================================================================== OVERVIEW
+   The glowmotion half: a small, authored-looking architecture diagram built
+   from overview.py's geometry. Crisp SVG so text stays sharp at any zoom;
+   dash-flow + SMIL comets so it animates with no per-frame JS cost.
+   Clicking a module hands off to the explore view, focused on that module. */
+
+const OV = G.overview || null;
+const svgNS = "http://www.w3.org/2000/svg";
+const el = (n, a) => {
+  const e = document.createElementNS(svgNS, n);
+  for (const k in (a || {})) e.setAttribute(k, a[k]);
+  return e;
+};
+
+function buildOverview() {
+  const host = document.getElementById("ovScroll");
+  if (!OV || !OV.boxes.length) {
+    host.innerHTML = '<div style="color:var(--fg3);font-size:12px;letter-spacing:.16em">' +
+      'No overview available for this graph.</div>';
+    return;
+  }
+  const W = OV.width, H = OV.height;
+  const svg = el("svg", {
+    id: "ovSvg", viewBox: "0 0 " + W + " " + H,
+    width: W, height: H, role: "img",
+    "aria-label": "Architecture overview of " + (G.project || {}).name,
+  });
+
+  // --- rows as faint bands, labelled on the left
+  const bands = el("g", {});
+  let lastLabel = null;
+  for (const r of OV.rows) {
+    const rowBoxes = OV.boxes.filter(b => b.row === r.row);
+    if (!rowBoxes.length) continue;
+    // A tier that wrapped onto a second row shouldn't repeat its heading.
+    const repeat = r.label === lastLabel;
+    lastLabel = r.label;
+    const h = Math.max(...rowBoxes.map(b => b.h));
+    const color = layerColor(r.layer);
+    const g = el("g", { color: color });
+    g.appendChild(el("rect", {
+      class: "ov-band", x: 8, y: r.y - 12, width: W - 16, height: h + 24, rx: 10,
+    }));
+    // Label above the band so it can never sit on top of a box.
+    if (!repeat) {
+      const t = el("text", { class: "ov-bandlabel", x: 14, y: r.y - 19 });
+      t.textContent = r.label;
+      g.appendChild(t);
+    }
+    bands.appendChild(g);
+  }
+  svg.appendChild(bands);
+
+  // --- connectors. The journey path is drawn last so it sits on top.
+  const journeyEdges = new Set(OV.journey.map(h => h[0] + ">" + h[1]));
+  const links = el("g", {});
+  const maxW = Math.max(1, ...OV.edges.map(e => e.weight));
+  for (const e of OV.edges) {
+    const onPath = journeyEdges.has(e.from + ">" + e.to);
+    const cls = "ov-link" + (onPath ? " path" : (e.weight > maxW * 0.35 ? " heavy" : ""));
+    const p = el("path", { class: cls, d: e.d, "data-from": e.from, "data-to": e.to });
+    if (!onPath) p.style.animationDelay = (hash(e.from + e.to) * -1.1) + "s";
+    links.appendChild(p);
+    // arrowhead at the target end, oriented by the final segment
+    const head = arrowAt(e.d, onPath);
+    if (head) links.appendChild(head);
+  }
+  svg.appendChild(links);
+
+  // --- module boxes
+  const boxes = el("g", {});
+  for (const b of OV.boxes) {
+    const color = layerColor(b.layer);
+    const g = el("g", { class: "ov-box", color: color, "data-mod": b.id,
+                        tabindex: "0", role: "button",
+                        "aria-label": b.path + ", " + b.fileCount + " files" });
+    g.appendChild(el("rect", { x: b.x, y: b.y, width: b.w, height: b.h, rx: 9 }));
+    const name = el("text", { class: "ov-name", x: b.x + 12, y: b.y + 24 });
+    name.textContent = b.label;
+    g.appendChild(name);
+    const meta = el("text", { class: "ov-meta", x: b.x + 12, y: b.y + 40 });
+    meta.textContent = b.fileCount + " files · " + b.loc.toLocaleString() + " loc" +
+                       (b.lang ? " · " + b.lang : "");
+    g.appendChild(meta);
+    // Show the entry marker only when entry points DOMINATE the module. A badge
+    // reading "entry" on a 12-file API package because 5 files match the
+    // heuristic is misleading — it made every box in a FastAPI app look like one.
+    if (b.entries && b.entries >= Math.max(2, b.fileCount * 0.5)) {
+      const badge = el("text", { class: "ov-badge", x: b.x + 12, y: b.y + 54 });
+      badge.textContent = b.entries + " entry point" + (b.entries > 1 ? "s" : "");
+      g.appendChild(badge);
+    } else if (b.tags && b.tags.length) {
+      const badge = el("text", { class: "ov-badge", x: b.x + 12, y: b.y + 54 });
+      badge.textContent = b.tags.slice(0, 2).join(" · ");
+      g.appendChild(badge);
+    }
+    // pulsing halo on the journey's own modules
+    if (OV.journey.some(h => h[0] === b.id || h[1] === b.id)) {
+      const halo = el("rect", { class: "ov-halo", x: b.x - 4, y: b.y - 4,
+                                width: b.w + 8, height: b.h + 8, rx: 12 });
+      halo.style.animationDelay = (OV.journey.findIndex(h => h[0] === b.id) * 0.35) + "s";
+      g.appendChild(halo);
+    }
+    g.addEventListener("click", () => drillInto(b.id));
+    g.addEventListener("keydown", ev => {
+      if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); drillInto(b.id); }
+    });
+    g.addEventListener("mouseenter", ev => ovTip(ev, b));
+    g.addEventListener("mouseleave", () => { document.getElementById("tip").style.display = "none"; });
+    boxes.appendChild(g);
+  }
+  svg.appendChild(boxes);
+
+  // --- the comet: one dot per journey hop, riding the exact connector path
+  const byPair = new Map(OV.edges.map(e => [e.from + ">" + e.to, e]));
+  const comets = el("g", {});
+  OV.journey.forEach((hop, i) => {
+    const e = byPair.get(hop[0] + ">" + hop[1]);
+    if (!e) return;
+    const dur = 1.5, begin = (i * dur / Math.max(1, OV.journey.length)).toFixed(2);
+    for (let t = 0; t < 3; t++) {          // head + two fading trail dots
+      const dot = el("circle", { class: t === 0 ? "ov-comet" : "ov-trail",
+                                 r: t === 0 ? 3.4 : (3.4 - t * 0.9) });
+      if (t) dot.setAttribute("opacity", 0.42 / t);
+      const mo = el("animateMotion", {
+        dur: dur + "s", repeatCount: "indefinite", path: e.d,
+        begin: (parseFloat(begin) + t * 0.055).toFixed(3) + "s",
+        calcMode: "linear", fill: "freeze",
+      });
+      dot.appendChild(mo);
+      comets.appendChild(dot);
+    }
+  });
+  svg.appendChild(comets);
+
+  host.innerHTML = "";
+  host.appendChild(svg);
+  const hint = document.createElement("div");
+  hint.id = "ovHint";
+  const p = G.project || {};
+  // Prefer the agent's description, but never cut it mid-sentence.
+  let blurb = (p.description || "").trim();
+  if (blurb.length > 190) {
+    const cut = blurb.lastIndexOf(". ", 190);
+    blurb = cut > 60 ? blurb.slice(0, cut + 1) : blurb.slice(0, 190).trim() + "…";
+  }
+  const facts = OV.boxes.length + " of " + (G.stats || {}).files_indexed +
+    " files, grouped by module · " + (p.languages || []).slice(0, 3).join(" · ");
+  hint.textContent = blurb || facts;
+  hint.title = facts;
+  host.appendChild(hint);
+}
+
+/* ================================================================== STAR MAP
+   The same modules, read as MASS rather than layers: each module is a galaxy,
+   each file a star whose brightness is its importance. Answers a different
+   question from the box overview — "where is the weight of this system?"
+
+   Star shading is ported from Physics-atlas' GLSL to Canvas 2D:
+     white-hot core   exp(-r^2 * 42)
+     two-layer halo   exp(-r*3.2)*0.55 + exp(-r*8)*0.5
+     diffraction spikes, only for the biggest stars
+   Canvas (not WebGL) keeps the single-file, zero-dependency contract. */
+
+const SM = G.overview && G.overview.starmap ? G.overview.starmap : null;
+const sky = document.getElementById("sky");
+const skyCv = document.getElementById("skyCv");
+const sctx = skyCv ? skyCv.getContext("2d") : null;
+
+/* Orbit camera over the galactic disc. Mirrors Physics-atlas' OrbitControls
+   contract — drag to rotate, wheel to dolly, damped inertia, slow auto-rotate
+   when idle — but as a 2D projection so we keep the zero-dependency, single-file
+   output. No three.js (~600KB) and no WebGL context needed. */
+const SKY = {
+  hover: null, t: 0, fit: 1, ox: 0, oy: 0, dust: [],
+  yaw: 0.5, pitch: 0.62,          // radians; pitch 0 = edge-on, PI/2 = top-down
+  vYaw: 0, vPitch: 0,             // angular velocity for the damped glide
+  zoom: 1, zoomTo: 1,             // dolly is smoothed, like the atlas' rig
+  panX: 0, panY: 0,
+  auto: 0.16,                     // idle auto-rotate speed (atlas uses 0.16)
+  idle: 0, drag: null,
+};
+const PITCH_MIN = 0.12, PITCH_MAX = 1.45;   // never fully edge-on or flat
+
+function skyResize() {
+  if (!sctx) return;
+  const w = sky.clientWidth, h = sky.clientHeight;
+  skyCv.width = w * DPR; skyCv.height = h * DPR;
+  sctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+  SKY.fit = Math.min(w / SM.width, h / SM.height) * 0.92;
+  SKY.ox = w / 2;
+  SKY.oy = h / 2;
+  if (!SKY.dust.length) {
+    const n = Math.round(Math.min(320, (w * h) / 5200));
+    for (let i = 0; i < n; i++) {
+      const a = hash("d" + i), b = hash("d2" + i), c = hash("d3" + i);
+      SKY.dust.push({ x: a * w, y: b * h, r: 0.3 + c * 0.9,
+                      ph: a * 6.283, sp: 0.3 + b * 0.9, warm: c > 0.85 });
+    }
+  }
+}
+
+/**
+ * Project a disc point to screen space.
+ * The field is modelled as a plane in XZ with Y as height; yaw spins it, pitch
+ * tilts it toward the viewer. Returns a depth term too, so callers can scale and
+ * fade by distance — that is what sells the third dimension without WebGL.
+ */
+function project(x, y, z) {
+  const cx = SM.width / 2, cy = SM.height / 2;
+  // Disc-local coords, centred.
+  const dx = x - cx, dz = y - cy, dy = (z || 0);
+  const cy_ = Math.cos(SKY.yaw), sy_ = Math.sin(SKY.yaw);
+  // yaw about the vertical axis
+  const rx = dx * cy_ - dz * sy_;
+  const rz = dx * sy_ + dz * cy_;
+  const cp = Math.cos(SKY.pitch), sp = Math.sin(SKY.pitch);
+  // pitch: tilt the plane, height contributes to screen Y
+  const sxp = rx;
+  const syp = rz * sp - dy * cp;
+  const depth = rz * cp + dy * sp;          // + = further away
+  // Weak perspective: enough to read depth, not enough to distort the field.
+  const persp = 1 / (1 + depth / 2400);
+  const s = SKY.fit * SKY.zoom * persp;
+  return {
+    x: SKY.ox + sxp * s + SKY.panX,
+    y: SKY.oy + syp * s + SKY.panY,
+    s: s, depth: depth, persp: persp,
+  };
+}
+
+/** One star, atlas-style: hot core, soft double halo, spikes when massive. */
+function paintStar(x, y, size, rgb, mag, spike) {
+  const outer = size * 4.2;
+  const g = sctx.createRadialGradient(x, y, 0, x, y, outer);
+  // Sampling the analytic falloff at a few stops is visually identical to the
+  // shader and far cheaper than per-pixel work in 2D.
+  g.addColorStop(0.00, "rgba(255,253,247," + (0.95 * mag) + ")");
+  g.addColorStop(0.10, "rgba(" + rgb + "," + (0.85 * mag) + ")");
+  g.addColorStop(0.30, "rgba(" + rgb + "," + (0.34 * mag) + ")");
+  g.addColorStop(0.60, "rgba(" + rgb + "," + (0.10 * mag) + ")");
+  g.addColorStop(1.00, "rgba(" + rgb + ",0)");
+  sctx.fillStyle = g;
+  sctx.beginPath(); sctx.arc(x, y, outer, 0, 7); sctx.fill();
+
+  if (spike > 0.02) {                     // diffraction cross for giants only
+    const len = size * (5 + spike * 9), a = 0.30 * spike * mag;
+    const lg = sctx.createLinearGradient(x - len, y, x + len, y);
+    lg.addColorStop(0, "rgba(" + rgb + ",0)");
+    lg.addColorStop(0.5, "rgba(255,255,255," + a + ")");
+    lg.addColorStop(1, "rgba(" + rgb + ",0)");
+    sctx.fillStyle = lg;
+    sctx.fillRect(x - len, y - size * 0.10, len * 2, size * 0.20);
+    const vg = sctx.createLinearGradient(x, y - len, x, y + len);
+    vg.addColorStop(0, "rgba(" + rgb + ",0)");
+    vg.addColorStop(0.5, "rgba(255,255,255," + a + ")");
+    vg.addColorStop(1, "rgba(" + rgb + ",0)");
+    sctx.fillStyle = vg;
+    sctx.fillRect(x - size * 0.10, y - len, size * 0.20, len * 2);
+  }
+}
+
+function rgbOf(layer) {
+  // "other" renders grey, which made the single most important module (a flat
+  // src/ root) the dullest thing on screen — the opposite of what the map claims.
+  const hex = layer === "other" || !layer ? "#a9b8e8" : layerColor(layer);
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  return m ? [parseInt(m[1],16), parseInt(m[2],16), parseInt(m[3],16)].join(",")
+           : "160,190,255";
+}
+
+function drawSky() {
+  if (!sctx || !SM) return;
+  const light = document.documentElement.dataset.theme === "light";
+  const w = sky.clientWidth, h = sky.clientHeight;
+  sctx.clearRect(0, 0, w, h);
+  sctx.globalCompositeOperation = light ? "source-over" : "lighter";
+
+  // background dust
+  if (!light) {
+    for (const d of SKY.dust) {
+      const tw = 0.55 + 0.45 * Math.sin(SKY.t * d.sp + d.ph);
+      sctx.fillStyle = (d.warm ? "rgba(201,138,75," : "rgba(190,210,255,") +
+                       (tw * 0.42) + ")";
+      sctx.beginPath(); sctx.arc(d.x, d.y, d.r, 0, 7); sctx.fill();
+    }
+  }
+
+  // Everything is projected once per frame, then painted far-to-near so nearer
+  // stars correctly overlap the ones behind them.
+  const gp = new Map();
+  for (const g2 of SM.galaxies) {
+    const p = project(g2.x, g2.y, g2.z);
+    p.g = g2;                    // attach after projecting, never spread over it
+    gp.set(g2.id, p);
+  }
+
+  // filaments between galaxies — the module dependencies
+  const maxW = Math.max(1, ...SM.links.map(l => l.weight));
+  for (const l of SM.links) {
+    const a = gp.get(l.from), b = gp.get(l.to);
+    if (!a || !b) continue;
+    const rel = l.weight / maxW;
+    const hot = SKY.hover && (SKY.hover === l.from || SKY.hover === l.to);
+    // Far filaments fade, which is what stops the field looking like flat spaghetti.
+    const near = Math.max(0.25, (a.persp + b.persp) / 2);
+    sctx.strokeStyle = light
+      ? "rgba(70,95,150," + ((0.10 + rel * 0.30 + (hot ? 0.35 : 0)) * near) + ")"
+      : "rgba(150,185,255," + ((0.05 + rel * 0.22 + (hot ? 0.40 : 0)) * near) + ")";
+    sctx.lineWidth = (0.5 + rel * 1.6 + (hot ? 0.9 : 0)) * near;
+    const mx = (a.x + b.x) / 2, my = (a.y + b.y) / 2;
+    const dx = b.x - a.x, dy = b.y - a.y;
+    const nlen = Math.hypot(dx, dy) || 1;
+    const bow = Math.min(46, nlen * 0.14);
+    sctx.beginPath();
+    sctx.moveTo(a.x, a.y);
+    sctx.quadraticCurveTo(mx - dy / nlen * bow, my + dx / nlen * bow, b.x, b.y);
+    sctx.stroke();
+  }
+
+  // nebula wash per galaxy
+  const galByDepth = [...gp.values()].sort((p, q) => q.depth - p.depth);
+  for (const p of galByDepth) {
+    const g2 = p.g;
+    const rgb = rgbOf(g2.layer);
+    const r = g2.r * p.s;
+    const dim = (SKY.hover && SKY.hover !== g2.id ? 0.30 : 1) * Math.max(0.35, p.persp);
+    const neb = sctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, r * 1.9);
+    neb.addColorStop(0, "rgba(" + rgb + "," + (light ? 0.10 : 0.13) * dim + ")");
+    neb.addColorStop(0.55, "rgba(" + rgb + "," + (light ? 0.05 : 0.05) * dim + ")");
+    neb.addColorStop(1, "rgba(" + rgb + ",0)");
+    sctx.fillStyle = neb;
+    sctx.beginPath(); sctx.arc(p.x, p.y, r * 1.9, 0, 7); sctx.fill();
+  }
+
+  // stars, far to near. NOTE: project() returns a field named `s` (scale), so the
+  // star object is carried as `star` — spreading it as `s` silently shadowed the id.
+  const proj = SM.stars.map(st => {
+    const p = project(st.x, st.y, st.z);
+    p.star = st;
+    return p;
+  });
+  proj.sort((a, b) => b.depth - a.depth);
+  for (const p of proj) {
+    const st = p.star;
+    const dim = (SKY.hover && SKY.hover !== st.mod ? 0.22 : 1) * Math.max(0.30, p.persp);
+    // breathing, small amplitude like the atlas — presence, not blinking
+    const puls = 1 + 0.05 * Math.sin(SKY.t * 1.25 + hash(st.id) * 6.283);
+    const size = (1.5 + st.mag * 5.2) * puls * Math.max(0.6, p.s);
+    paintStar(p.x, p.y, size, rgbOf(st.layer),
+              (light ? 0.55 : 1) * dim * (0.35 + st.mag * 0.65),
+              Math.max(0, st.mag - 0.62) * 2.2);
+  }
+
+  // galaxy labels last so they sit on top of the glow
+  sctx.globalCompositeOperation = "source-over";
+  sctx.textAlign = "center";
+  // Biggest galaxies get a heavier label: on a crowded field the eye needs a
+  // ranking, and LOC is the honest proxy for "how much lives here".
+  const maxLoc = Math.max(1, ...SM.galaxies.map(g2 => g2.loc));
+  for (const p of galByDepth) {
+    const g2 = p.g;
+    const x = p.x, y = p.y + g2.r * p.s + 15;
+    const focus = SKY.hover === g2.id;
+    const dim = (SKY.hover && !focus ? 0.35 : 1) * Math.max(0.4, p.persp);
+    const major = g2.loc > maxLoc * 0.35;
+    sctx.font = (focus || major ? "600 " : "") + (focus ? 12.5 : major ? 11.5 : 10) +
+                "px ui-sans-serif,system-ui,sans-serif";
+    const txt = g2.label;
+    sctx.lineWidth = 3.2;
+    sctx.strokeStyle = light ? "rgba(255,255,255,.95)" : "rgba(3,4,10,.95)";
+    sctx.lineJoin = "round";
+    sctx.globalAlpha = dim;
+    sctx.strokeText(txt, x, y);
+    sctx.fillStyle = light ? "#141a2c" : "#eaf0ff";
+    sctx.fillText(txt, x, y);
+    if (focus) {
+      sctx.font = "9.5px ui-monospace,'SF Mono',Menlo,monospace";
+      sctx.fillStyle = light ? "rgba(20,26,44,.7)" : "rgba(220,232,255,.7)";
+      sctx.fillText(g2.files + " files · " + g2.loc.toLocaleString() + " loc", x, y + 14);
+    }
+    sctx.globalAlpha = 1;
+  }
+}
+
+/** Which galaxy is under the pointer? */
+function skyHit(px, py) {
+  if (!SM) return null;
+  let best = null, bd = 1e9;
+  for (const g2 of SM.galaxies) {
+    const p = project(g2.x, g2.y, g2.z);
+    const d = Math.hypot(p.x - px, p.y - py);
+    // Nearer galaxies win ties: they are the ones visually on top.
+    if (d < g2.r * p.s * 1.25 && d - p.depth * 0.02 < bd) {
+      bd = d - p.depth * 0.02; best = g2;
+    }
+  }
+  return best;
+}
+
+/** Damped camera integration, run once per frame from the animation loop. */
+function skyTick(dt) {
+  // Auto-rotate only after the reader has been still for a moment — motion that
+  // fights your hand is worse than no motion.
+  SKY.idle += dt;
+  if (!SKY.drag && SKY.idle > 2.5 && !SKY.hover) {
+    SKY.yaw += SKY.auto * dt * 0.35;
+  }
+  // Inertia: keep gliding after release, then settle (atlas dampingFactor .055).
+  if (!SKY.drag) {
+    SKY.yaw += SKY.vYaw * dt;
+    SKY.pitch += SKY.vPitch * dt;
+    const k = Math.pow(0.0025, dt);        // frame-rate independent decay
+    SKY.vYaw *= k; SKY.vPitch *= k;
+    if (Math.abs(SKY.vYaw) < 1e-4) SKY.vYaw = 0;
+    if (Math.abs(SKY.vPitch) < 1e-4) SKY.vPitch = 0;
+  }
+  SKY.pitch = Math.max(PITCH_MIN, Math.min(PITCH_MAX, SKY.pitch));
+  // Smooth dolly toward the wheel target rather than snapping.
+  SKY.zoom += (SKY.zoomTo - SKY.zoom) * Math.min(1, dt * 9);
+}
+
+function skyReset() {
+  SKY.yaw = 0.5; SKY.pitch = 0.62; SKY.zoomTo = SKY.zoom = 1;
+  SKY.panX = SKY.panY = 0; SKY.vYaw = SKY.vPitch = 0; SKY.idle = 0;
+  drawSky();
+}
+
+if (skyCv) {
+  const local = ev => [ev.clientX, ev.clientY - 56];
+
+  skyCv.addEventListener("mousedown", ev => {
+    ev.preventDefault();
+    SKY.drag = { x: ev.clientX, y: ev.clientY, yaw: SKY.yaw, pitch: SKY.pitch,
+                 panX: SKY.panX, panY: SKY.panY, moved: false,
+                 pan: ev.button === 2 || ev.shiftKey, lx: ev.clientX, ly: ev.clientY };
+    SKY.vYaw = SKY.vPitch = 0;
+    skyCv.style.cursor = "grabbing";
+  });
+  skyCv.addEventListener("contextmenu", ev => ev.preventDefault());
+
+  addEventListener("mousemove", ev => {
+    if (SKY.drag) {
+      const d = SKY.drag;
+      const dx = ev.clientX - d.x, dy = ev.clientY - d.y;
+      if (Math.abs(dx) + Math.abs(dy) > 3) d.moved = true;
+      if (d.pan) {                          // shift/right-drag pans the field
+        SKY.panX = d.panX + dx;
+        SKY.panY = d.panY + dy;
+      } else {
+        SKY.yaw = d.yaw - dx * 0.005;
+        SKY.pitch = d.pitch + dy * 0.005;
+        // Velocity from the last mouse delta feeds the release glide.
+        SKY.vYaw = -(ev.clientX - d.lx) * 0.30;
+        SKY.vPitch = (ev.clientY - d.ly) * 0.30;
+      }
+      d.lx = ev.clientX; d.ly = ev.clientY;
+      SKY.idle = 0;
+      drawSky();
+      return;
+    }
+    if (S.mode !== "star") return;
+    const [px, py] = local(ev);
+    const g2 = skyHit(px, py);
+    const id = g2 ? g2.id : null;
+    if (id !== SKY.hover) { SKY.hover = id; SKY.idle = 0; drawSky(); }
+    const tip = document.getElementById("tip");
+    if (g2) {
+      tip.style.display = "block";
+      tip.style.left = Math.min(ev.clientX + 14, innerWidth - 380) + "px";
+      tip.style.top = (ev.clientY + 16) + "px";
+      tip.textContent = g2.label + "  ·  " + g2.files + " files" +
+        (g2.summary ? "  —  " + g2.summary.slice(0, 130) : "");
+    } else tip.style.display = "none";
+  });
+
+  addEventListener("mouseup", ev => {
+    if (!SKY.drag) return;
+    const moved = SKY.drag.moved;
+    SKY.drag = null;
+    skyCv.style.cursor = "grab";
+    // A click (not a drag) on a galaxy still drills into explore.
+    if (!moved && S.mode === "star") {
+      const [px, py] = local(ev);
+      const g2 = skyHit(px, py);
+      if (g2) drillInto(g2.id);
+    }
+  });
+
+  skyCv.addEventListener("wheel", ev => {
+    ev.preventDefault();
+    SKY.zoomTo = Math.max(0.35, Math.min(6, SKY.zoomTo * Math.exp(-ev.deltaY * 0.0016)));
+    SKY.idle = 0;
+  }, { passive: false });
+
+  skyCv.addEventListener("mouseleave", () => {
+    if (SKY.drag) return;
+    SKY.hover = null; document.getElementById("tip").style.display = "none"; drawSky();
+  });
+
+  // Touch: one finger orbits, two pinch-zoom.
+  let pinch = 0;
+  skyCv.addEventListener("touchstart", ev => {
+    if (ev.touches.length === 1) {
+      const t0 = ev.touches[0];
+      SKY.drag = { x: t0.clientX, y: t0.clientY, yaw: SKY.yaw, pitch: SKY.pitch,
+                   panX: SKY.panX, panY: SKY.panY, moved: false, pan: false,
+                   lx: t0.clientX, ly: t0.clientY };
+    } else if (ev.touches.length === 2) {
+      pinch = Math.hypot(ev.touches[0].clientX - ev.touches[1].clientX,
+                         ev.touches[0].clientY - ev.touches[1].clientY);
+    }
+  }, { passive: true });
+  skyCv.addEventListener("touchmove", ev => {
+    if (ev.touches.length === 2 && pinch) {
+      const d = Math.hypot(ev.touches[0].clientX - ev.touches[1].clientX,
+                           ev.touches[0].clientY - ev.touches[1].clientY);
+      SKY.zoomTo = Math.max(0.35, Math.min(6, SKY.zoomTo * (d / pinch)));
+      pinch = d;
+      SKY.idle = 0;
+      ev.preventDefault();
+      return;
+    }
+    if (SKY.drag && ev.touches.length === 1) {
+      const t0 = ev.touches[0], d = SKY.drag;
+      SKY.yaw = d.yaw - (t0.clientX - d.x) * 0.005;
+      SKY.pitch = d.pitch + (t0.clientY - d.y) * 0.005;
+      SKY.idle = 0;
+      ev.preventDefault();
+      drawSky();
+    }
+  }, { passive: false });
+  skyCv.addEventListener("touchend", () => { SKY.drag = null; pinch = 0; }, { passive: true });
+}
+
+/** Arrowhead marker built from the last segment of an orthogonal path. */
+function arrowAt(d, onPath) {
+  const pts = d.match(/-?\d+(\.\d+)?/g);
+  if (!pts || pts.length < 4) return null;
+  const n = pts.map(Number);
+  const x2 = n[n.length - 2], y2 = n[n.length - 1];
+  const x1 = n[n.length - 4], y1 = n[n.length - 3];
+  const ang = Math.atan2(y2 - y1, x2 - x1);
+  const s = 4.6;
+  const p1 = [x2, y2];
+  const p2 = [x2 - Math.cos(ang - 0.45) * s, y2 - Math.sin(ang - 0.45) * s];
+  const p3 = [x2 - Math.cos(ang + 0.45) * s, y2 - Math.sin(ang + 0.45) * s];
+  return el("polygon", {
+    class: "ov-arrow" + (onPath ? " path" : ""),
+    points: [p1, p2, p3].map(p => p[0].toFixed(1) + "," + p[1].toFixed(1)).join(" "),
+  });
+}
+
+function ovTip(ev, b) {
+  const tip = document.getElementById("tip");
+  tip.style.display = "block";
+  tip.style.left = Math.min(ev.clientX + 14, innerWidth - 380) + "px";
+  tip.style.top = (ev.clientY + 16) + "px";
+  tip.textContent = b.path + (b.summary ? "  —  " + b.summary.slice(0, 150) : "");
+}
+
+/* ---- the handoff that makes this one tool instead of two ---- */
+function drillInto(modId) {
+  setMode("explore");
+  S.view = "file";
+  const box = OV.boxes.find(b => b.id === modId);
+  if (box) S.hiddenLayers.delete(box.layer);
+  // In hierarchy mode the target must be un-collapsed before it can be framed.
+  if (S.hier) openTo(modId);
+  syncUI();
+  rebuild();
+  document.querySelectorAll("[data-layer]").forEach(e2 =>
+    e2.classList.toggle("off", S.hiddenLayers.has(e2.dataset.layer)));
+
+  // Frame the module's FILES rather than the module box: a file has real
+  // import edges to inspect, and a group of them fills the viewport sensibly.
+  const kids = (childrenOf.get(modId) || []).map(k => byId.get(k))
+    .filter(n => n && n.x !== undefined);
+  if (!kids.length) { if (byId.has(modId)) focusNode(modId); return; }
+
+  frameNodes(kids);
+  const lead = kids.slice().sort((a, b) => (b.importance || 0) - (a.importance || 0))[0];
+  select(lead.id);
+  buildPackets();
+}
+
+/**
+ * Build a self-contained question about a node and put it on the clipboard.
+ * The artifact is offline and holds no API key, so rather than pretend to host a
+ * chat we hand you a prompt that already carries the graph facts an LLM would
+ * otherwise have to guess: path, summary, both edge directions, symbols.
+ */
+function copyAskContext(n) {
+  const outs = (adjOut.get(n.id) || []), ins = (adjIn.get(n.id) || []);
+  const nameOf = id => (byId.get(id) || {}).filePath || (byId.get(id) || {}).name || id;
+  const L = [];
+  L.push("I am reading the codebase `" + ((G.project || {}).name || "?") + "`" +
+         ((G.project || {}).languages ? " (" + G.project.languages.slice(0, 3).join(", ") + ")" : "") + ".");
+  L.push("");
+  L.push("Question: what does this do, why does it exist, and what should I know before changing it?");
+  L.push("");
+  L.push("## " + (n.filePath || n.name));
+  if (n.summary) L.push("Summary" + (n.summarySource === "docstring" ? " (its own docstring)" : "") +
+                        ": " + n.summary);
+  const facts = [];
+  if (n.loc) facts.push(n.loc + " LOC");
+  if (n.layer) facts.push("layer: " + n.layer);
+  if (n.fanIn !== undefined) facts.push("imported by " + n.fanIn);
+  if (n.fanOut !== undefined) facts.push("imports " + n.fanOut);
+  if (n.importance !== undefined) facts.push("importance " + n.importance);
+  if (facts.length) L.push("Facts: " + facts.join(" · "));
+  if (n.routes && n.routes.length) L.push("HTTP routes: " + n.routes.join(", "));
+  if (n.symbols && n.symbols.length) L.push("Defines: " + n.symbols.join(", "));
+  if (outs.length) L.push("Depends on: " +
+    outs.slice(0, 14).map(e => nameOf(e.target)).join(", "));
+  if (ins.length) L.push("Used by: " +
+    ins.slice(0, 14).map(e => nameOf(e.source)).join(", "));
+  const text = L.join("\n");
+
+  const done = ok => {
+    const b = document.querySelector("[data-ask]");
+    if (!b) return;
+    b.textContent = ok ? "copied ✓" : "copy failed";
+    setTimeout(() => { b.textContent = "ask ▸"; }, 1600);
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(() => done(true), () => done(false));
+  } else {                                   // file:// fallback
+    const ta = document.createElement("textarea");
+    ta.value = text; document.body.appendChild(ta); ta.select();
+    let ok = false;
+    try { ok = document.execCommand("copy"); } catch (e) { ok = false; }
+    document.body.removeChild(ta);
+    done(ok);
+  }
+}
+
+/** Fit the viewport around a set of nodes, with padding for the side panels. */
+function frameNodes(list) {
+  let x0 = 1e9, y0 = 1e9, x1 = -1e9, y1 = -1e9;
+  for (const n of list) {
+    x0 = Math.min(x0, n.x - n.r); x1 = Math.max(x1, n.x + n.r);
+    y0 = Math.min(y0, n.y - n.r); y1 = Math.max(y1, n.y + n.r);
+  }
+  const padL = 250, padR = 360, padT = 90, padB = 110, margin = 90;
+  const w = (x1 - x0) + margin * 2 || 1, h = (y1 - y0) + margin * 2 || 1;
+  S.scale = Math.max(0.12, Math.min(1.7,
+    Math.min((innerWidth - padL - padR) / w, (innerHeight - padT - padB) / h)));
+  S.tx = padL + (innerWidth - padL - padR) / 2 - (x0 + x1) / 2 * S.scale;
+  S.ty = padT + (innerHeight - padT - padB) / 2 - (y0 + y1) / 2 * S.scale;
+  draw();
+}
+
+function setMode(m) {
+  if (m === "star" && !SM) m = "overview";     // no star data: degrade gracefully
+  S.mode = m;
+  const isOv = m === "overview", isSky = m === "star", isEx = m === "explore";
+  document.getElementById("ov").classList.toggle("show", isOv);
+  document.getElementById("ovLegend").classList.toggle("show", isOv);
+  if (sky) sky.classList.toggle("show", isSky);
+  document.getElementById("stage").style.display = isEx ? "block" : "none";
+  document.getElementById("mOverview").classList.toggle("on", isOv);
+  document.getElementById("mStar").classList.toggle("on", isSky);
+  document.getElementById("mExplore").classList.toggle("on", isEx);
+  // Controls that only mean something in the explore view.
+  for (const id of ["view", "bImports", "bCalls", "bExt", "bEntry", "bCycles", "bFit",
+                    "bFold", "bHood", "bHier"]) {
+    const b = document.getElementById(id);
+    if (b) b.style.display = isEx ? "" : "none";
+  }
+  document.getElementById("rail").style.display = isEx ? "" : "none";
+  if (!isEx) {
+    select(null);
+    document.getElementById("tip").style.display = "none";
+    if (S.tourIdx >= 0) closeTour();   // a tour has no meaning without the graph
+  }
+  else if (!VN.length) rebuild();
+  if (isSky) {
+    skyResize();
+    document.getElementById("skyHint").textContent =
+      "drag to orbit · scroll to zoom · shift-drag to pan · 0 to reset · click a galaxy";
+    drawSky();
+  }
+}
+
+/* ------------------------------------------------------------------ picking */
+function toWorld(px, py) {
+  return { x:(px - S.tx)/S.scale, y:(py - S.ty)/S.scale };
+}
+function hitTest(px, py) {
+  const p = toWorld(px, py);
+  let best = null, bd = 1e9;
+  for (const n of VN) {
+    if (n.x === undefined) continue;
+    const d = Math.hypot(n.x-p.x, n.y-p.y);
+    if (d <= n.r + 5 && d < bd) { bd = d; best = n; }
+  }
+  return best;
+}
+
+let drag = null;
+cv.addEventListener("mousedown", ev => {
+  drag = { x:ev.clientX, y:ev.clientY, tx:S.tx, ty:S.ty, moved:false };
+  cv.classList.add("dragging");
+});
+addEventListener("mousemove", ev => {
+  if (drag) {
+    const dx = ev.clientX-drag.x, dy = ev.clientY-drag.y;
+    if (Math.abs(dx)+Math.abs(dy) > 3) drag.moved = true;
+    S.tx = drag.tx+dx; S.ty = drag.ty+dy;
+    draw();
+    return;
+  }
+  const n = hitTest(ev.clientX, ev.clientY);
+  const tip = document.getElementById("tip");
+  if (n) {
+    if (S.hover !== n.id) { S.hover = n.id; draw(); }
+    tip.style.display = "block";
+    tip.style.left = Math.min(ev.clientX+13, innerWidth-350) + "px";
+    tip.style.top  = (ev.clientY+15) + "px";
+    tip.textContent = (n.filePath || n.name) +
+      (n.lineRange ? ":" + n.lineRange[0] : "") +
+      (n.loc ? "  ·  " + n.loc + " LOC" : "");
+  } else {
+    if (S.hover) { S.hover = null; draw(); }
+    tip.style.display = "none";
+  }
+});
+addEventListener("mouseup", ev => {
+  if (drag && !drag.moved) {
+    const n = hitTest(ev.clientX, ev.clientY);
+    // In hierarchy mode a click means "open (or close) this level"; the inspector
+    // still updates, so one gesture both reveals and explains.
+    // NOTE: no early return here — the drag cleanup below must always run.
+    if (n && S.hier && (hiddenChildCount(n) > 0 || n.type === "module" ||
+                        S.openFiles.has(n.id))) {
+      select(n.id);
+      toggleExpand(n.id);
+    }
+    // Clicking a folded hub reveals its edges instead of just selecting it —
+    // the badge is a promise that the detail is one click away.
+    else if (n && isFoldedHub(n.id)) {
+      S.expanded.add(n.id);
+      select(n.id);
+      rebuild();
+      draw();
+    } else {
+      select(n ? n.id : null);
+    }
+  }
+  drag = null; cv.classList.remove("dragging");
+});
+cv.addEventListener("wheel", ev => {
+  ev.preventDefault();
+  const k = Math.exp(-ev.deltaY * 0.0013);
+  const ns = Math.max(0.05, Math.min(5, S.scale * k));
+  S.tx = ev.clientX - (ev.clientX - S.tx) * (ns/S.scale);
+  S.ty = ev.clientY - (ev.clientY - S.ty) * (ns/S.scale);
+  S.scale = ns; draw();
+}, { passive:false });
+
+/* ------------------------------------------------------------------ inspector */
+const esc = s => String(s == null ? "" : s)
+  .replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+
+function select(id) {
+  S.selected = id;
+  const box = document.getElementById("info");
+  if (!id) { box.classList.remove("show"); draw(); return; }
+  const n = byId.get(id);
+  if (!n) { box.classList.remove("show"); draw(); return; }
+
+  const cells = [];
+  const push = (k,v) => { if (v !== undefined && v !== null && v !== "")
+    cells.push('<div class="cell"><div class="k">'+k+'</div><div class="v">'+esc(v)+'</div></div>'); };
+  push("LOC", n.loc);
+  push("Layer", LAYER_NAMES[n.layer] || n.layer);
+  push("Imported by", n.fanIn);
+  push("Imports", n.fanOut);
+  push("Language", n.language);
+  push("Files", n.fileCount);
+  push("Symbols", n.defCount);
+  push("Used by", n.usedBy);
+  if (n.lineRange) push("Lines", n.lineRange[0] + "–" + n.lineRange[1]);
+  if (n.importance !== undefined) push("Importance", n.importance.toFixed(3));
+
+  const rel = (list, dir) => {
+    if (!list || !list.length) return '<div class="empty">none</div>';
+    return '<ul class="rel">' + list.slice(0,40).map(e => {
+      const other = byId.get(dir === "out" ? e.target : e.source);
+      if (!other) return "";
+      return '<li data-goto="'+esc(other.id)+'"><span class="ico">'+e.type.slice(0,9)+
+             '</span><span class="nm">'+esc(other.name)+'</span></li>';
+    }).join("") + '</ul>';
+  };
+  const outs = (adjOut.get(id)||[]), ins = (adjIn.get(id)||[]);
+  const kids = (childrenOf.get(id)||[]).map(k => ({ target:k, type:"contains" }));
+
+  box.innerHTML =
+    '<div class="kind">'+esc(n.kind || n.type)+
+      '<button data-ask title="Copy a ready-made question about this node for any LLM">ask ▸</button>'+
+    '</div>' +
+    '<h3>'+esc(n.name)+'</h3>' +
+    '<div class="path">'+esc(n.filePath || n.id)+'</div>' +
+    (n.summary
+      ? '<div class="sum'+(n.summarySource==="docstring"?' doc':'')+'">'+esc(n.summary)+
+        (n.summarySource==="docstring"?'<i>from the file\u2019s docstring</i>':'')+'</div>'
+      : '<div class="sum none">This file has no docstring and no AI summary.</div>') +
+    (n.tags && n.tags.length
+      ? '<div class="tags">'+n.tags.map(t=>'<span class="tag">'+esc(t)+'</span>').join("")+'</div>' : "") +
+    '<div class="grid">'+cells.join("")+'</div>' +
+    (n.routes && n.routes.length
+      ? '<h4>Routes</h4><div class="tags">'+n.routes.map(r=>'<span class="tag">'+esc(r)+'</span>').join("")+'</div>' : "") +
+    // What's actually inside this file — the question "what does it define?"
+    (n.symbols && n.symbols.length
+      ? '<h4>Defines <span>'+n.symbols.length+(n.defCount>n.symbols.length?'+':'')+
+        '</span></h4><div class="tags">'+
+        n.symbols.map(s=>'<span class="tag">'+esc(s)+'</span>').join("")+'</div>' : "") +
+    '<h4>Depends on <span>'+outs.length+'</span></h4>' + rel(outs,"out") +
+    '<h4>Used by <span>'+ins.length+'</span></h4>' + rel(ins,"in") +
+    (kids.length ? '<h4>Contains <span>'+kids.length+'</span></h4>' + rel(kids,"out") : "");
+
+  box.classList.add("show");
+  box.querySelectorAll("[data-goto]").forEach(el =>
+    el.onclick = () => focusNode(el.dataset.goto));
+  const askBtn = box.querySelector("[data-ask]");
+  if (askBtn) askBtn.onclick = () => copyAskContext(n);
+  syncUI();                // the focus button depends on there being a selection
+  if (S.neighborhood) rebuild();   // the visible set follows the selection
+  buildPackets();          // re-weight traffic toward the newly focused node
+  draw();
+}
+
+function focusNode(id) {
+  const n = byId.get(id);
+  if (!n) return;
+  const names = ["module","file","symbol"];
+  const want = tier(n);
+  // Hierarchy mode: open the ancestor chain instead of switching detail level.
+  if (S.hier) {
+    if (n.module) openTo(n.module);
+    else if (n.type === "module") openTo(n.id);
+    if (n.filePath && n.id.startsWith("sym:")) S.openFiles.add("file:" + n.filePath);
+  }
+  // Reveal a deeper detail level (and un-hide its layer) so the target can exist.
+  else if (STRUCT[S.view] < want) { S.view = names[want]; }
+  if (n.type === "external" && !S.ext) S.ext = true;
+  S.hiddenLayers.delete(n.layer || "other");
+  syncUI();
+  rebuild();
+  document.querySelectorAll("[data-layer]").forEach(el =>
+    el.classList.toggle("off", S.hiddenLayers.has(el.dataset.layer)));
+  if (n.x !== undefined) {
+    S.scale = Math.max(S.scale, 0.85);
+    S.tx = innerWidth/2 - n.x*S.scale - 40;
+    S.ty = innerHeight/2 - n.y*S.scale;
+  }
+  select(id);
+}
+
+/* ------------------------------------------------------------------ search */
+const searchEl = document.getElementById("search");
+searchEl.addEventListener("input", () => {
+  S.query = searchEl.value.trim();
+  const wrap = document.getElementById("hitsWrap"), ul = document.getElementById("hits");
+  if (!S.query) { wrap.style.display = "none"; draw(); return; }
+  const hits = NODES.filter(matches)
+    .sort((a,b) => (b.importance||0)-(a.importance||0)).slice(0,60);
+  ul.innerHTML = hits.map(n =>
+    '<li data-id="'+esc(n.id)+'" title="'+esc(n.filePath||n.id)+'">'+esc(n.name)+
+    ' <span style="color:var(--fg3)">'+esc((n.layer||""))+'</span></li>').join("")
+    || '<li class="empty">no matches</li>';
+  ul.querySelectorAll("[data-id]").forEach(li =>
+    li.onclick = () => focusNode(li.dataset.id));
+  wrap.style.display = "block";
+  draw();
+});
+
+/* ------------------------------------------------------------------ tours */
+function currentTourNodes() {
+  const t = (G.tour||[])[S.tourIdx];
+  if (!t) return new Set();
+  return new Set(t.steps.map(s => s.nodeId));
+}
+function showTour(i, step = 0) {
+  const tours = G.tour || [];
+  if (!tours.length) return;
+  // Tour steps point at graph nodes, so it can only be followed in explore.
+  if (S.mode !== "explore") setMode("explore");
+  S.tourIdx = ((i % tours.length) + tours.length) % tours.length;
+  S.tourStep = step;
+  const t = tours[S.tourIdx];
+  S.tourStep = Math.max(0, Math.min(step, t.steps.length-1));
+  const st = t.steps[S.tourStep];
+  document.getElementById("tour").classList.add("show");
+  document.getElementById("tTitle").textContent = t.title;
+  document.getElementById("tCount").textContent =
+    (S.tourStep+1) + " / " + t.steps.length +
+    (tours.length > 1 ? "  ·  tour " + (S.tourIdx+1) + "/" + tours.length : "");
+  const n = byId.get(st.nodeId);
+  document.getElementById("tNote").innerHTML =
+    "<b>" + esc(n ? n.name : st.nodeId) + "</b> — " + esc(st.note || "");
+  document.querySelector("#bar div").style.width =
+    ((S.tourStep+1)/t.steps.length*100) + "%";
+  document.getElementById("bTour").classList.add("on");
+  focusNode(st.nodeId);
+}
+function stepTour(d) {
+  const t = (G.tour||[])[S.tourIdx];
+  if (!t) return;
+  const next = S.tourStep + d;
+  if (next < 0) showTour(S.tourIdx-1, 0);
+  else if (next >= t.steps.length) {
+    const tours = G.tour||[];
+    if (S.tourIdx+1 < tours.length) showTour(S.tourIdx+1, 0);
+    else showTour(S.tourIdx, t.steps.length-1);
+  } else showTour(S.tourIdx, next);
+}
+function closeTour() {
+  S.tourIdx = -1;
+  document.getElementById("tour").classList.remove("show");
+  document.getElementById("bTour").classList.remove("on");
+  draw();
+}
+document.getElementById("tPrev").onclick = () => stepTour(-1);
+document.getElementById("tNext").onclick = () => stepTour(1);
+document.getElementById("tClose").onclick = closeTour;
+
+/* ------------------------------------------------------------------ chrome */
+function syncUI() {
+  document.getElementById("view").value = S.view;
+  document.getElementById("bImports").classList.toggle("on", S.imports);
+  document.getElementById("bCalls").classList.toggle("on", S.calls);
+  document.getElementById("bExt").classList.toggle("on", S.ext);
+  document.getElementById("bEntry").classList.toggle("on", S.entries);
+  document.getElementById("bCycles").classList.toggle("on", S.cycles);
+  document.getElementById("bFold").classList.toggle("on", S.foldHubs);
+  document.getElementById("bHier").classList.toggle("on", S.hier);
+  // The detail-level select is meaningless while the hierarchy drives depth.
+  const vsel = document.getElementById("view");
+  if (vsel) vsel.disabled = S.hier;
+  const hood = document.getElementById("bHood");
+  hood.classList.toggle("on", S.neighborhood);
+  hood.disabled = !S.selected;        // meaningless with nothing selected
+  hood.title = S.selected
+    ? "Show only this node and its direct neighbours (N)"
+    : "Select a node first, then focus on its neighbourhood (N)";
+}
+const toggle = (id, key, relayout) => {
+  document.getElementById(id).onclick = () => {
+    S[key] = !S[key]; syncUI();
+    relayout ? rebuild() : draw();
+  };
+};
+toggle("bImports","imports",true);
+toggle("bCalls","calls",true);
+toggle("bExt","ext",true);
+toggle("bHier","hier",true);
+toggle("bFold","foldHubs",true);
+toggle("bHood","neighborhood",true);
+toggle("bEntry","entries",false);
+toggle("bCycles","cycles",false);
+document.getElementById("view").onchange = e => { S.view = e.target.value; rebuild(); };
+document.getElementById("bFit").onclick = () => fit();
+document.getElementById("mOverview").onclick = () => setMode("overview");
+document.getElementById("mStar").onclick = () => setMode("star");
+document.getElementById("mExplore").onclick = () => setMode("explore");
+document.getElementById("bMotion").onclick = () => setMotion(!M.on);
+document.getElementById("bTheme").onclick = () => {
+  const el = document.documentElement;
+  el.dataset.theme = el.dataset.theme === "light" ? "dark" : "light";
+  draw();
+};
+document.getElementById("bTour").onclick = () => {
+  // No alert(): a modal blocks the page and says nothing the UI can't show.
+  // The button is disabled up-front when the graph carries no tours.
+  if (!(G.tour||[]).length) return;
+  S.tourIdx >= 0 ? closeTour() : showTour(0, 0);
+};
+
+addEventListener("keydown", ev => {
+  if (ev.target.tagName === "INPUT") {
+    if (ev.key === "Escape") { ev.target.value=""; S.query=""; 
+      document.getElementById("hitsWrap").style.display="none"; ev.target.blur(); draw(); }
+    return;
+  }
+  if (ev.key === "Tab") {          // Tab cycles overview -> star map -> explore
+    ev.preventDefault();
+    const order = SM ? ["overview", "star", "explore"] : ["overview", "explore"];
+    setMode(order[(order.indexOf(S.mode) + 1) % order.length]);
+    return;
+  }
+  const k = ev.key.toLowerCase();
+  if (k === "/") { ev.preventDefault(); searchEl.focus(); }
+  else if (k === "0") { S.mode === "star" ? skyReset() : fit(); }
+  else if (k === "t") document.getElementById("bTheme").click();
+  else if (k === "p") document.getElementById("bTour").click();
+  else if (k === "escape") { select(null); closeTour(); }
+  else if (k === "[") stepTour(-1);
+  else if (k === "]") stepTour(1);
+  else if (k === " ") { ev.preventDefault(); setMotion(!M.on); }
+  else if (k === "f") document.getElementById("bFold").click();
+  else if (k === "h") document.getElementById("bHier").click();
+  else if (k === "n") { if (!document.getElementById("bHood").disabled)
+    document.getElementById("bHood").click(); }
+});
+
+/* ---- rail ---- */
+let statRows = [];
+
+/** Update just the live counts (edges shown / folded) after a rebuild. */
+function refreshStats() {
+  const row = document.querySelector('#stats [data-live="edges"]');
+  if (row) row.textContent = VE.length + (foldedCount ? "  (−" + foldedCount + ")" : "");
+}
+
+function buildRail() {
+  const p = G.project || {};
+  const st = [
+    ["Files", (G.stats||{}).files_indexed || NODES.filter(n=>tier(n)===1).length],
+    ["Lines of code", (p.totalLoc||0).toLocaleString()],
+    ["Graph nodes", NODES.length],
+    ["Relationships", EDGES.filter(e=>e.type!=="contains").length],
+    ["Edges shown", VE.length + (foldedCount ? "  (−" + foldedCount + " folded)" : "")],
+    ["AI summaries", G.enrichedNodes || 0],
+    ["Cycles", (G.cycles||[]).length],
+  ];
+  statRows = st;   // kept so refreshStats() can redraw counts after a rebuild
+  document.getElementById("stats").innerHTML = st.map(([k,v]) =>
+    '<div class="stat"><span>'+k+'</span><b'+
+    (k === "Edges shown" ? ' data-live="edges"' : '')+'>'+v+'</b></div>').join("");
+  document.getElementById("sub").textContent =
+    (p.languages||[]).slice(0,3).join(" · ") +
+    ((p.frameworks||[]).length ? "  ·  " + p.frameworks.slice(0,3).join(" · ") : "");
+
+  // Entry points: the answer to "where do I start reading?" as a clickable list.
+  const entries = NODES.filter(n => n.isEntry && n.type === "file")
+    .sort((a, b) => (b.importance || 0) - (a.importance || 0)).slice(0, 6);
+  if (entries.length) {
+    document.getElementById("startHere").style.display = "";
+    document.getElementById("entryList").innerHTML = entries.map(n =>
+      '<div data-entry="' + esc(n.id) + '" title="' + esc(n.filePath) + '"><b>' +
+      esc(n.name) + '</b><i>' + esc((n.filePath || "").split("/").slice(0, -1).join("/")) +
+      (n.routes && n.routes.length ? "  ·  " + n.routes.length + " routes" : "") +
+      '</i></div>').join("");
+    document.querySelectorAll("[data-entry]").forEach(el =>
+      el.onclick = () => { setMode("explore"); focusNode(el.dataset.entry); });
+  }
+
+  const counts = {};
+  for (const n of NODES) counts[n.layer||"other"] = (counts[n.layer||"other"]||0) + 1;
+  const order = BAND_ORDER.filter(b => counts[b]);
+  document.getElementById("layers").innerHTML = order.map(b =>
+    '<div class="lyr" data-layer="'+b+'" title="'+esc(
+        (G.layers||[]).find(l=>l.id===b)?.description || "")+'">' +
+    '<span class="dot" style="color:'+layerColor(b)+';background:'+layerColor(b)+'"></span>' +
+    '<span>'+esc(LAYER_NAMES[b]||b)+'</span><span class="ct">'+counts[b]+'</span></div>').join("");
+  document.querySelectorAll("[data-layer]").forEach(el => {
+    // Reflect the initial hidden set (tests start off) so the rail never lies.
+    el.classList.toggle("off", S.hiddenLayers.has(el.dataset.layer));
+    el.onclick = () => {
+      const b = el.dataset.layer;
+      S.hiddenLayers.has(b) ? S.hiddenLayers.delete(b) : S.hiddenLayers.add(b);
+      el.classList.toggle("off", S.hiddenLayers.has(b));
+      rebuild();
+      draw();
+    };
+  });
+}
+
+/* Open the tree along the path to the project's entry point, so the first thing
+   you see is "here is where execution starts" rather than a wall of folders. */
+function openAtEntry() {
+  S.open.clear();
+  S.open.add(ROOT_MOD);
+  const entry = NODES
+    .filter(n => n.isEntry && n.type === "file")
+    .sort((a, b) => (b.importance || 0) - (a.importance || 0))[0];
+  // Open just the first two levels. Walking the whole chain to the entry point
+  // also reveals every sibling at every level (~82 rows on this repo), which
+  // forces a 0.28 scale where the text is unreadable. The reader clicks down; the
+  // rail's "jump to entry" gets them there in one step when they want it.
+  for (const k of (MOD_KIDS.get(ROOT_MOD) || [])) {
+    const kn = byId.get(k);
+    // Expand a lone wrapper directory (src/) since it teaches nothing on its own.
+    if (kn && (MOD_KIDS.get(k) || []).length === 1 && !(MOD_FILES.get(k) || []).length) {
+      S.open.add(k);
+    }
+  }
+  return entry;
+}
+
+/* ---- boot ---- */
+const bootEntry = openAtEntry();
+buildRail(); syncUI(); rebuild(); resize();
+buildOverview();
+// Open on the overview: the 5-second read comes first, detail on demand.
+// A one-box overview teaches nothing, so flat projects land in explore instead.
+const ovWorthShowing = OV && OV.boxes.length >= 2;
+setMode(ovWorthShowing ? "overview" : "explore");
+if (!ovWorthShowing) document.getElementById("mOverview").disabled = !(OV && OV.boxes.length);
+// Tours only exist after the enrich stage; show that state instead of failing on click.
+if (!(G.tour || []).length) {
+  const tb = document.getElementById("bTour");
+  tb.disabled = true;
+  tb.title = "No guided tours — run the enrich stage to generate them";
+}
+setMotion(!REDUCED);
+requestAnimationFrame(frame);
+if ((G.tour||[]).length && location.hash === "#tour") showTour(0,0);
+const h = decodeURIComponent(location.hash.replace(/^#(focus=)?/,""));
+if (h && byId.has(h)) focusNode(h);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## TL;DR

Adds **codegraph** — a skill that turns any codebase into an explorable interactive graph, so a developer can understand an unfamiliar repo in minutes instead of weeks. Output is one self-contained HTML file: no CDN, no server, and no API key required to view it.

Registered under the existing `core-skills` plugin, so anyone who already has that plugin gets it on next update.

## Why

"Help me understand this codebase" is one of the most common things people ask an agent, and the honest answer today is a wall of prose. A graph is a better medium for it — but only if the structure is trustworthy. That constraint drove the design below.

## How it works

Three stages, and only the middle one uses an LLM:

```
1. scan.py     codebase   ->  graph.json + digest.md    deterministic · no LLM · no network
2. the agent   digest.md  ->  enrich.json               summaries · layer fixes · tours
3. render.py   both       ->  codegraph.html            validated · atomic · portable
   └ overview.py collapses the file graph into the module-level overview diagram
```

**Why the split matters:** structure is reproducible — the same commit always yields the same edges — while meaning is left to the model (what a file is *for*, not just what it imports). The agent reads a compact `digest.md` instead of the full graph, so enrichment stays cheap even on large repos. `enrich.json` is stored separately from `graph.json`, so re-scanning after a refactor preserves existing summaries.

`render.py` validates before writing and delivers atomically: a broken artifact never replaces a good one.

## What the skill produces

- **An overview diagram** — 8–14 module boxes on architectural layer bands with flowing connectors and an animated primary path. Derived from the scan, so it cannot drift from the real code.
- **An orbitable star map** — the same modules as a galaxy field where brightness = importance. Drag to orbit, scroll to dolly. Projected 2.5D in Canvas, so no three.js and no WebGL.
- **A drill-down explore view** — click a module to jump into the detailed graph focused on its files, with an expandable tree (folders → files → symbols) and a **Start here** list of real entry points.
- **Self-documenting nodes** — summaries extracted from the codebase's own docstrings/JSDoc: 87% coverage on a real 109k-LOC repo with zero model calls. The agent overrides them where it can do better, and the UI labels which is which.
- **Structural analysis** — PageRank importance ranking, auto-detected layers (entry → api → service → data → util), dependency cycles flagged as refactor targets, and entry-point detection.
- **`ask ▸` on every node** — copies a prompt carrying the node's summary, metrics, symbols and both dependency directions, ready to paste into any LLM. No API key is ever embedded, since the artifact gets shared.

## Files added

| Path | Purpose |
|---|---|
| `skills/codegraph/SKILL.md` | Agent-facing contract: triggers, pipeline rules, step-by-step instructions |
| `skills/codegraph/scripts/scan.py` | Deterministic extraction (files, imports, symbols, metrics, cycles) |
| `skills/codegraph/scripts/overview.py` | Collapses the file graph into the module overview |
| `skills/codegraph/scripts/render.py` | Validates and builds the portable HTML artifact |
| `skills/codegraph/scripts/viewer.html` | Viewer shell as plain markup, so CSS/animation tweaks don't mean editing a Python string |
| `skills/codegraph/scripts/test_codegraph.py` | 103 tests |

Modified: `.claude-plugin/marketplace.json` (register under `core-skills`) and `README.md` (skills table + repository structure).

## Supported languages

Python · JS/TS (+JSX/TSX) · Vue · Svelte · Go · Rust · Java · Kotlin · Scala · Ruby · PHP · C# · C/C++ · Objective-C · Swift · shell · SQL · Terraform · GraphQL · Protobuf — plus config, docs, and Docker as context nodes.

Import resolution handles relative paths, package roots, `@/` aliases, Go modules, Rust `crate::`/`mod`, and JVM packages.

## Performance

| Repo | Result |
|---|---|
| 231,747 LOC / 256 files | scanned in **2.3s** → 2,660 nodes, 14,479 relationships |
| 2,600-node symbol view | laid out in **33ms** (spatial-hash relaxation) |
| animation @ 2,660 nodes | **60fps** (static scene cached; only the motion overlay repaints) |

Python 3.8+ stdlib only. Zero third-party dependencies in either stage, so nothing to install.

## Testing

```bash
python3 skills/codegraph/scripts/test_codegraph.py     # 103 tests, all passing
```

Covers cross-language import resolution, symbol extraction, cycle detection, determinism, validation gates, enrichment merging, unicode/escaping safety, atomic-delivery rollback, the animation-layer contract, and the overview's geometry contract (no overlapping boxes, everything inside the canvas, journeys that follow real edges).

Also verified end-to-end against this repository itself: scanned 55 files / 16,049 LOC → 223 nodes, 318 edges, 0 cycles, rendering a 230 KB self-contained artifact.

## Honest limits

Documented in `SKILL.md` rather than glossed over:

- Extraction is regex-based, not a full type-checking AST. Excellent for imports and definitions; **`calls` edges are heuristic** (unique unambiguous names only) and presented as hints, never verified fact.
- Dynamic imports, DI containers, reflection, and runtime registration are invisible to static analysis.
- Layers are path heuristics until the agent overrides them in `enrich.json`.

## Notes for reviewers

- **No assets shipped.** The upstream project has preview PNGs and a live demo HTML (~1.7 MB), but no existing skill in this repo ships images, so this PR is scripts-only at 276 KB. Nothing in `SKILL.md` references those assets, so there are no broken links. Happy to add a skill-level README with screenshots if you'd prefer.
- **`author: SylphAI-Inc`** retained in the frontmatter.
- Design informed by [archify](https://github.com/tt-a1i/archify) (typed IR, validate-before-deliver, single portable artifact) and [Understand-Anything](https://github.com/Egonex-AI/Understand-Anything) (deterministic-parser + LLM hybrid, layer/tour model).

🌸 Generated with [AdaL](https://github.com/adal-cli/)
