### PR TITLE
feat: add finger-frame AI video skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,8 @@
         "./skills/posthog-analytics",
         "./skills/clone-anywebsite",
         "./skills/glowmotion",
-        "./skills/codegraph"
+        "./skills/codegraph",
+        "./skills/finger-frame-ai"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After installation, see all your available skills:
 | [clone-anywebsite](./skills/clone-anywebsite/SKILL.md) | Clone any website's landing page with pixel-perfect fidelity — visual-first workflow with sniper CSS extraction, animation detection, and mandatory Builder+Evaluator pattern |
 | [glowmotion](./skills/glowmotion/SKILL.md) | Create premium animated technical diagrams (flowcharts, architecture diagrams, Mermaid conversions) as single self-contained HTML+SVG files with glowing comet-dot flows, pulsing highlights, and a built-in light/dark theme toggle |
 | [codegraph](./skills/codegraph/SKILL.md) | Turn any codebase into an explorable interactive graph — deterministic structural scan (imports, symbols, PageRank importance, architectural layers, dependency cycles, entry points) plus AI summaries and guided tours, delivered as one self-contained HTML file |
+| [finger-frame-ai](./skills/finger-frame-ai/SKILL.md) | Generate an AI-restyled world inside a tracked two-hand finger-frame gesture using Gemini Omni, MediaPipe, and FFmpeg |
 
 ### SWE CLI Skills (`swe-cli-skills` plugin)
 

--- a/skills/finger-frame-ai/.gitignore
+++ b/skills/finger-frame-ai/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.task
+*.mp4
+*.mov
+*.webm

--- a/skills/finger-frame-ai/README.md
+++ b/skills/finger-frame-ai/README.md
@@ -1,0 +1,28 @@
+# Finger Frame AI
+
+Create a video where a two-hand finger-frame gesture reveals an AI-restyled version of the scene.
+
+The effect and processing pipeline originate from
+[`sophiamyang/finger-frame-effect-ai`](https://github.com/sophiamyang/finger-frame-effect-ai).
+
+This skill bundles a guided Python runner that:
+
+- Creates an isolated virtual environment.
+- Uses Gemini Omni to restyle the source timeline.
+- Tracks both hands with MediaPipe.
+- Composites the restyled clip inside the finger frame with FFmpeg/OpenCV.
+- Preserves source audio and leaves the original untouched.
+
+## Requirements
+
+- Python 3.10+
+- `ffmpeg` and `ffprobe` on `PATH`
+- A Gemini API key with `gemini-omni-flash-preview` access and quota
+
+Configure the key locally:
+
+```bash
+export GEMINI_API_KEY='...'
+```
+
+Then ask AdaL to apply the Finger Frame AI effect to an absolute local video path. Gemini video generation may take several minutes and may incur API charges.

--- a/skills/finger-frame-ai/SKILL.md
+++ b/skills/finger-frame-ai/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: finger-frame-ai
+description: Generate a finished finger-frame effect video from a local clip using Gemini Omni restyling, MediaPipe hand tracking, and FFmpeg compositing. Use when someone asks to make, create, restyle, or process a video where a two-hand finger-frame becomes a window into an AI-stylized world.
+author: shangliy
+version: 1.0.0
+---
+
+# Finger Frame AI
+
+Turn a local video of the two-hand finger-frame gesture into an H.264 MP4 where the area inside the fingers reveals an AI-restyled version of the scene.
+
+The bundled pipeline uses:
+
+1. **Gemini Omni** to restyle the existing clip while asking it to preserve timing, motion, framing, pose, and expression.
+2. **MediaPipe Hand Landmarker** to track both index fingers and thumbs.
+3. **FFmpeg/OpenCV** to composite the restyled video into the tracked quadrilateral and retain source audio.
+
+## When to Use
+
+Trigger when the user asks to:
+
+- Apply a finger-frame, hand-frame, or fingers-as-a-window video effect.
+- Put an anime, claymation, watercolor, CGI, or custom AI world inside a finger gesture.
+- Run the Finger Frame AI video pipeline on a local clip.
+
+Do not substitute Veo video generation. This effect needs a restyled version of the existing timeline so it can align with hand tracking from the source.
+
+## Required Input and Consent
+
+Ask for the **absolute local source-video path** if it was not supplied.
+
+The Gemini Omni request can take several minutes and may incur Google API charges. Before calling it, clearly state that and obtain confirmation unless the user already authorized the paid generation in the current conversation.
+
+A key with `gemini-omni-flash-preview` access and quota is required. Never ask the user to paste a key into chat. Ask them to configure it in the terminal that launches AdaL:
+
+```bash
+export GEMINI_API_KEY='...'
+```
+
+`GOOGLE_API_KEY` is also supported. Never print, log, commit, or place a key in command arguments.
+
+## Instructions
+
+Set `<skill>` to this skill directory, then perform these steps.
+
+### 1. Check readiness
+
+```bash
+python3 <skill>/scripts/process.py --check
+```
+
+This check does not install packages, upload media, or call Gemini. If FFmpeg is missing, tell the user to install `ffmpeg` and `ffprobe`; do not attempt privileged installation.
+
+### 2. Validate the source
+
+Confirm the file exists. The clip should clearly show two hands forming opposing index-and-thumb “L” shapes. Preserve the original file.
+
+Short clips are faster and cheaper. Sources larger than 15 MB are automatically compressed to a temporary 720p H.264 upload copy; the original remains untouched.
+
+### 3. Generate
+
+Default 3D animated-movie style:
+
+```bash
+python3 <skill>/scripts/process.py "/absolute/path/to/input.mov"
+```
+
+Custom style:
+
+```bash
+python3 <skill>/scripts/process.py "/absolute/path/to/input.mov" \
+  --prompt "Transform the scene into hand-painted watercolor animation while preserving the original motion and framing."
+```
+
+Optional output controls:
+
+```bash
+python3 <skill>/scripts/process.py input.mp4 \
+  --output /absolute/path/to/result.mp4 \
+  --keep-stylized
+```
+
+The runner automatically:
+
+- Creates/reuses `<skill>/.venv`.
+- Installs bundled Python requirements when missing.
+- Prompts for a hidden, non-persisted key only in an interactive terminal.
+- Creates and cleans up an oversized-source working copy.
+- Runs Gemini Omni restyling and local finger-frame compositing.
+- Deletes the intermediate fully stylized video unless `--keep-stylized` is set.
+- Writes the default result beside the source as `<source>-finger-frame.mp4`.
+
+In headless AdaL, always provide the video path and set the key in AdaL's launching environment because hidden prompts require a terminal.
+
+### 4. Verify and report
+
+After completion, run `ffprobe` on the final file. Report:
+
+- Absolute output path
+- Duration
+- Resolution and frame rate
+- Video/audio codecs
+- File size
+
+Do not claim success unless the file exists, is non-empty, and FFmpeg can decode it without errors.
+
+## Error Handling
+
+- **HTTP 429 / quota 0:** Stop. Ask the user to enable billing/quota or configure another key. Do not retry repeatedly.
+- **Authentication failure:** Ask the user to replace the locally configured key. Never request it in chat.
+- **No tracked frame:** Explain that both hands and spread index/thumb shapes must be visible.
+- **Large upload still exceeds limit:** Ask the user to trim the clip or explicitly choose a larger `--max-upload-mb` only if their API supports it.
+- **Generation drift:** Explain that Omni is generative and cannot guarantee mathematical frame-perfect alignment.
+- **Interrupted run:** Preserve the original and remove only pipeline-created temporary media.

--- a/skills/finger-frame-ai/scripts/composite.py
+++ b/skills/finger-frame-ai/scripts/composite.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Composite an AI-restyled video inside a tracked finger frame.
+
+Tracks the finger-frame gesture (both hands, index + thumb "L"s) in the
+original footage with MediaPipe Hand Landmarker, then reveals the stylized
+video through the quad the fingers form — the same window effect as the
+finger-frame-effect web app, with the dashed outline and corner dots.
+
+The tracking logic is a direct port of the web app's audited pipeline:
+anatomical corner ordering (crossed fingers = bowtie), spread/area gates
+with hysteresis, teleport rejection, velocity-adaptive smoothing, dropout
+hold, and presence fade.
+
+Usage:
+    python composite.py finger-effect-raw.mp4 stylized.mp4 -o final.mp4
+"""
+
+import argparse
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import urllib.request
+
+import cv2
+import numpy as np
+
+MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/hand_landmarker/"
+    "hand_landmarker/float16/1/hand_landmarker.task"
+)
+MODEL_PATH = Path(__file__).resolve().parent.parent / "hand_landmarker.task"
+
+WRIST, THUMB_TIP, INDEX_TIP, MIDDLE_MCP = 0, 4, 8, 9
+
+# Tracking constants — mirror main.js in the web app.
+MAX_LOST_FRAMES = 25
+JUMP_CONFIRM_FRAMES = 2
+JUMP_FRACTION = 0.3
+ALPHA_MIN, ALPHA_MAX = 0.35, 0.85
+ALPHA_SCALE = 0.05
+PRESENCE_IN, PRESENCE_OUT = 0.12, 0.05
+SPREAD_ACQUIRE, SPREAD_KEEP = 0.75, 0.2
+AREA_ACQUIRE, AREA_KEEP = 0.005, 0.0005
+
+
+def dist(a, b):
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def lerp_pt(a, b, t):
+    return (a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t)
+
+
+def polygon_area(pts):
+    a = 0.0
+    for i in range(len(pts)):
+        p, q = pts[i], pts[(i + 1) % len(pts)]
+        a += p[0] * q[1] - q[0] * p[1]
+    return abs(a / 2)
+
+
+def angle_sorted(pts):
+    cx = sum(p[0] for p in pts) / len(pts)
+    cy = sum(p[1] for p in pts) / len(pts)
+    return sorted(pts, key=lambda p: math.atan2(p[1] - cy, p[0] - cx))
+
+
+class FrameTracker:
+    """Stateful quad tracker, ported from the web app's main loop."""
+
+    def __init__(self, width, height):
+        self.w, self.h = width, height
+        self.corners = None
+        self.presence = 0.0
+        self.frame_active = False
+        self.lost_frames = 0
+        self.jump_frames = 0
+
+    def compute_quad(self, hands):
+        """hands: list of landmark lists (normalized). Returns anatomical quad
+        [A.index, B.index, B.thumb, A.thumb] (A = smaller wrist x) or None."""
+        if len(hands) != 2:
+            return None
+        info = []
+        for lm in hands:
+            px = lambda i: (lm[i].x * self.w, lm[i].y * self.h)
+            index, thumb = px(INDEX_TIP), px(THUMB_TIP)
+            scale = dist(px(WRIST), px(MIDDLE_MCP)) + 1
+            needed = SPREAD_KEEP if self.frame_active else SPREAD_ACQUIRE
+            if dist(thumb, index) < scale * needed:
+                return None
+            info.append({"index": index, "thumb": thumb, "wx": px(WRIST)[0]})
+        info.sort(key=lambda hd: hd["wx"])
+        a, b = info
+        pts = [a["index"], b["index"], b["thumb"], a["thumb"]]
+        min_area = AREA_KEEP if self.frame_active else AREA_ACQUIRE
+        if polygon_area(angle_sorted(pts)) < self.w * self.h * min_area:
+            return None
+        return pts
+
+    def update(self, hands):
+        target = self.compute_quad(hands) if hands else None
+
+        if target:
+            if self.corners is None:
+                self.lost_frames = 0
+                self.frame_active = True
+                self.jump_frames = 0
+                self.corners = target
+                self.presence = min(1.0, self.presence + PRESENCE_IN)
+            else:
+                moved = sum(dist(p, c) for p, c in zip(target, self.corners)) / 4
+                if (
+                    moved > self.w * JUMP_FRACTION
+                    and self.jump_frames + 1 < JUMP_CONFIRM_FRAMES
+                ):
+                    self.jump_frames += 1
+                    self.lost_frames += 1
+                    if self.lost_frames > MAX_LOST_FRAMES:
+                        self.presence = max(0.0, self.presence - PRESENCE_OUT)
+                else:
+                    self.lost_frames = 0
+                    self.frame_active = True
+                    self.jump_frames = 0
+                    alpha = min(
+                        ALPHA_MAX, max(ALPHA_MIN, moved / (self.w * ALPHA_SCALE))
+                    )
+                    self.corners = [
+                        lerp_pt(c, p, alpha) for c, p in zip(self.corners, target)
+                    ]
+                    self.presence = min(1.0, self.presence + PRESENCE_IN)
+        elif self.corners is not None and self.lost_frames < MAX_LOST_FRAMES:
+            self.lost_frames += 1
+            self.presence = min(1.0, self.presence + PRESENCE_IN)
+        else:
+            self.presence = max(0.0, self.presence - PRESENCE_OUT)
+            if self.presence == 0:
+                self.corners = None
+                self.frame_active = False
+                self.jump_frames = 0
+
+        return self.corners if self.presence > 0.01 else None
+
+
+def draw_outline(frame, quad, presence, t):
+    """Dashed marching-ants outline + pulsing corner dots, like the web app."""
+    overlay = frame.copy()
+
+    # Dashed edges with a marching offset.
+    dash_on, dash_off = 10.0, 8.0
+    period = dash_on + dash_off
+    offset = (t * 40.0) % period
+    for i in range(4):
+        p0 = np.array(quad[i], dtype=float)
+        p1 = np.array(quad[(i + 1) % 4], dtype=float)
+        seg = p1 - p0
+        length = float(np.hypot(*seg))
+        if length < 1:
+            continue
+        u = seg / length
+        s = -offset
+        while s < length:
+            a = max(0.0, s)
+            b = min(length, s + dash_on)
+            if b > a:
+                pa = (p0 + u * a).astype(int)
+                pb = (p0 + u * b).astype(int)
+                cv2.line(overlay, tuple(pa), tuple(pb), (242, 242, 242), 2, cv2.LINE_AA)
+            s += period
+
+    # Corner dots with pulse + expanding halo.
+    for i, p in enumerate(quad):
+        c = (int(p[0]), int(p[1]))
+        r = 7 + math.sin(t * 3 + i * 1.5) * 1.5
+        halo = (t * 0.8 + i * 0.25) % 1.0
+        halo_val = int(255 * 0.5 * (1 - halo))
+        cv2.circle(overlay, c, int(r + halo * 14), (halo_val,) * 3, 2, cv2.LINE_AA)
+        cv2.circle(overlay, c, int(r), (255, 255, 255), -1, cv2.LINE_AA)
+        cv2.circle(overlay, c, int(r), (60, 60, 60), 1, cv2.LINE_AA)
+
+    cv2.addWeighted(overlay, presence, frame, 1 - presence, 0, dst=frame)
+
+
+def ensure_model():
+    if not os.path.exists(MODEL_PATH):
+        print("Downloading hand landmarker model …")
+        urllib.request.urlretrieve(MODEL_URL, MODEL_PATH)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("original", nargs="?", default="finger-effect-raw.mp4")
+    ap.add_argument("stylized", nargs="?", default="stylized.mp4")
+    ap.add_argument("-o", "--output", default="final.mp4")
+    args = ap.parse_args()
+
+    for f in (args.original, args.stylized):
+        if not os.path.exists(f):
+            sys.exit(f"Missing input: {f}")
+    ensure_model()
+
+    import mediapipe as mp
+    from mediapipe.tasks import python as mp_tasks
+    from mediapipe.tasks.python import vision
+
+    cap = cv2.VideoCapture(args.original)
+    sty = cv2.VideoCapture(args.stylized)
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    sty_fps = sty.get(cv2.CAP_PROP_FPS) or fps
+    sty_count = int(sty.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    landmarker = vision.HandLandmarker.create_from_options(
+        vision.HandLandmarkerOptions(
+            base_options=mp_tasks.BaseOptions(model_asset_path=str(MODEL_PATH)),
+            running_mode=vision.RunningMode.VIDEO,
+            num_hands=2,
+            min_hand_detection_confidence=0.3,
+            min_hand_presence_confidence=0.3,
+            min_tracking_confidence=0.3,
+        )
+    )
+
+    # Pipe frames straight into ffmpeg for a proper H.264 output.
+    ff = subprocess.Popen(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "rawvideo", "-pix_fmt", "bgr24", "-s", f"{w}x{h}",
+            "-r", f"{fps}", "-i", "-",
+            "-c:v", "libx264", "-crf", "18", "-pix_fmt", "yuv420p",
+            args.output,
+        ],
+        stdin=subprocess.PIPE,
+    )
+
+    tracker = FrameTracker(w, h)
+    sty_frames = []
+    i = 0
+    tracked = 0
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+
+        # Cache stylized frames lazily (they're reused when fps differ).
+        t = i / fps
+        j = min(int(round(t * sty_fps)), max(sty_count - 1, 0))
+        while len(sty_frames) <= j:
+            ok_s, sf = sty.read()
+            if not ok_s:
+                break
+            if sf.shape[:2] != (h, w):
+                sf = cv2.resize(sf, (w, h))
+            sty_frames.append(sf)
+        sty_frame = sty_frames[min(j, len(sty_frames) - 1)] if sty_frames else None
+
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        result = landmarker.detect_for_video(
+            mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb),
+            int(i * 1000 / fps),
+        )
+        quad = tracker.update(result.hand_landmarks or [])
+
+        if quad is not None and sty_frame is not None:
+            tracked += 1
+            mask = np.zeros((h, w), dtype=np.uint8)
+            cv2.fillPoly(mask, [np.array(quad, dtype=np.int32)], 255)
+            m = (mask.astype(np.float32) / 255.0 * tracker.presence)[..., None]
+            frame = (
+                frame.astype(np.float32) * (1 - m)
+                + sty_frame.astype(np.float32) * m
+            ).astype(np.uint8)
+            draw_outline(frame, quad, tracker.presence, t)
+
+        ff.stdin.write(frame.tobytes())
+        i += 1
+        if i % 30 == 0:
+            print(f"  frame {i}, frame visible on {tracked} frames so far")
+
+    ff.stdin.close()
+    ff.wait()
+    cap.release()
+    sty.release()
+
+    # Carry over the original audio track if there is one.
+    has_audio = (
+        subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "a", "-show_entries",
+             "stream=codec_type", "-of", "csv=p=0", args.original],
+            capture_output=True, text=True,
+        ).stdout.strip() != ""
+    )
+    if has_audio:
+        tmp = args.output + ".mux.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-i", args.output,
+             "-i", args.original, "-map", "0:v", "-map", "1:a",
+             "-c:v", "copy", "-c:a", "aac", "-shortest", tmp],
+            check=True,
+        )
+        os.replace(tmp, args.output)
+
+    print(f"Done: {args.output} ({i} frames, finger frame visible on {tracked})")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/finger-frame-ai/scripts/process.py
+++ b/skills/finger-frame-ai/scripts/process.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Run the complete Finger Frame AI pipeline with guided setup."""
+
+import argparse
+import getpass
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+VENV_DIR = SKILL_DIR / ".venv"
+REQUIREMENTS = SCRIPT_DIR / "requirements.txt"
+STYLIZE_SCRIPT = SCRIPT_DIR / "stylize.py"
+COMPOSITE_SCRIPT = SCRIPT_DIR / "composite.py"
+VENV_MARKER = "FINGER_FRAME_VENV_READY"
+DEFAULT_MAX_UPLOAD_MB = 15
+AUDIO_BITRATE_KBPS = 128
+
+
+def venv_python(venv_dir=VENV_DIR):
+    return venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def run_command(command, *, env=None):
+    print("+", " ".join(map(str, command)))
+    subprocess.run([str(part) for part in command], check=True, env=env)
+
+
+def dependencies_available():
+    try:
+        import cv2  # noqa: F401
+        import mediapipe  # noqa: F401
+        import numpy  # noqa: F401
+        from google import genai  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def ensure_environment():
+    """Create the project virtual environment and re-exec inside it if needed."""
+    if os.environ.get(VENV_MARKER) == "1" and dependencies_available():
+        return
+
+    python = venv_python()
+    if not python.exists():
+        print(f"Creating virtual environment at {VENV_DIR} …")
+        run_command([sys.executable, "-m", "venv", VENV_DIR])
+
+    check = subprocess.run(
+        [str(python), "-c", "import cv2, mediapipe, numpy; from google import genai"],
+        capture_output=True,
+    )
+    if check.returncode != 0:
+        print("Installing Python dependencies …")
+        run_command([python, "-m", "pip", "install", "-r", REQUIREMENTS])
+
+    env = os.environ.copy()
+    env[VENV_MARKER] = "1"
+    os.execve(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+
+
+def resolve_video(value):
+    while not value:
+        if not sys.stdin.isatty():
+            raise SystemExit("Provide a local video path as the first argument.")
+        value = input("Local video path: ").strip()
+
+    video = Path(value).expanduser().resolve()
+    if not video.is_file():
+        raise SystemExit(f"Input video not found: {video}")
+    return video
+
+
+def resolve_api_key():
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if key:
+        return key
+    if not sys.stdin.isatty():
+        raise SystemExit(
+            "Set GEMINI_API_KEY or GOOGLE_API_KEY before running in headless mode."
+        )
+    key = getpass.getpass("Gemini API key (hidden, not saved): ").strip()
+    if not key:
+        raise SystemExit("A Gemini API key is required.")
+    return key
+
+
+def default_output(video):
+    return video.parent / f"{video.stem}-finger-frame.mp4"
+
+
+def probe_duration(video):
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(video),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return float(result.stdout.strip())
+
+
+def prepare_upload(video, output_dir, max_upload_mb):
+    max_bytes = int(max_upload_mb * 1_000_000)
+    if video.stat().st_size <= max_bytes:
+        return video, False
+
+    duration = probe_duration(video)
+    if duration <= 0:
+        raise SystemExit("Could not determine a valid source-video duration.")
+
+    target_total_kbps = max_bytes * 8 * 0.94 / duration / 1000
+    video_kbps = max(300, int(target_total_kbps - AUDIO_BITRATE_KBPS))
+    working = output_dir / f"{video.stem}-working-720p.mp4"
+
+    print(
+        f"Source exceeds {max_upload_mb:g} MB; creating a 720p upload copy at "
+        f"{working} …"
+    )
+    run_command(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            video,
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a:0?",
+            "-vf",
+            "scale=-2:720",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-b:v",
+            f"{video_kbps}k",
+            "-c:a",
+            "aac",
+            "-b:a",
+            f"{AUDIO_BITRATE_KBPS}k",
+            "-movflags",
+            "+faststart",
+            working,
+        ]
+    )
+    if working.stat().st_size > max_bytes:
+        working.unlink()
+        raise SystemExit(
+            "The compressed upload is still too large. Trim the source clip or "
+            "raise --max-upload-mb if your Gemini quota supports larger files."
+        )
+    return working, True
+
+
+def check_readiness():
+    missing = [
+        command for command in ("ffmpeg", "ffprobe") if shutil.which(command) is None
+    ]
+    print(f"Python: {sys.version.split()[0]}")
+    print(f"ffmpeg: {'missing' if 'ffmpeg' in missing else 'ready'}")
+    print(f"ffprobe: {'missing' if 'ffprobe' in missing else 'ready'}")
+    print(f"virtualenv: {'ready' if venv_python().exists() else 'will be created'}")
+    print(
+        "Gemini key: "
+        + (
+            "configured"
+            if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+            else "not configured"
+        )
+    )
+    return not missing
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("video", nargs="?", help="Path to the source video")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check local prerequisites without installing or generating anything",
+    )
+    parser.add_argument("-o", "--output", help="Final MP4 path")
+    parser.add_argument("-p", "--prompt", help="Custom video restyling prompt")
+    parser.add_argument(
+        "--keep-stylized",
+        action="store_true",
+        help="Keep the intermediate fully stylized video",
+    )
+    parser.add_argument(
+        "--max-upload-mb",
+        type=float,
+        default=DEFAULT_MAX_UPLOAD_MB,
+        help=f"Compress sources larger than this many MB (default: {DEFAULT_MAX_UPLOAD_MB})",
+    )
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    if args.check:
+        raise SystemExit(0 if check_readiness() else 1)
+
+    video = resolve_video(args.video)
+
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        raise SystemExit("ffmpeg and ffprobe must be installed and available on PATH.")
+
+    ensure_environment()
+    key = resolve_api_key()
+
+    output = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else default_output(video)
+    )
+    if output == video:
+        raise SystemExit("Output path must be different from the source video.")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    stylized = output.with_name(f"{output.stem}-stylized.mp4")
+    upload, upload_is_temporary = prepare_upload(
+        video, output.parent, args.max_upload_mb
+    )
+
+    env = os.environ.copy()
+    env["GEMINI_API_KEY"] = key
+
+    stylize_command = [
+        sys.executable,
+        STYLIZE_SCRIPT,
+        upload,
+        "-o",
+        stylized,
+    ]
+    if args.prompt:
+        stylize_command.extend(["--prompt", args.prompt])
+
+    try:
+        run_command(stylize_command, env=env)
+        run_command(
+            [
+                sys.executable,
+                COMPOSITE_SCRIPT,
+                upload,
+                stylized,
+                "-o",
+                output,
+            ],
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"Pipeline stage failed with exit code {exc.returncode}.") from exc
+    finally:
+        if stylized.exists() and not args.keep_stylized:
+            stylized.unlink()
+        if upload_is_temporary and upload.exists():
+            upload.unlink()
+
+    print(f"Finger-frame video ready: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/finger-frame-ai/scripts/requirements.txt
+++ b/skills/finger-frame-ai/scripts/requirements.txt
@@ -1,0 +1,4 @@
+mediapipe>=0.10.14
+opencv-python>=4.9
+numpy>=1.26
+google-genai>=1.0

--- a/skills/finger-frame-ai/scripts/stylize.py
+++ b/skills/finger-frame-ai/scripts/stylize.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Restyle a video with Gemini Omni Flash (video-to-video editing).
+
+The whole clip is regenerated per the prompt while motion and framing are
+preserved, so the result stays aligned with the original footage and
+composite.py can use the finger frame as a window over it.
+
+Usage:
+    export GEMINI_API_KEY=...   # https://aistudio.google.com/apikey
+    python stylize.py finger-effect-raw.mp4 -o stylized.mp4
+
+Docs: https://ai.google.dev/gemini-api/docs/omni
+"""
+
+import argparse
+import os
+import sys
+import time
+
+MODEL = "gemini-omni-flash-preview"
+DEFAULT_PROMPT = (
+    "Transform the person into a 3D animated movie character (stylized CGI "
+    "animation look, expressive big eyes, soft lighting). This is a strict "
+    "pixel-aligned edit of the source video: keep the same pose, motion, "
+    "timing, clothing colors, and background. The camera must not change — "
+    "no zoom, no crop, no recentering, and no change to the field of view. "
+    "The person's face and body must stay at exactly the same position and "
+    "size in the frame as the source: eyes, nose, and mouth must remain at "
+    "the same screen coordinates in every frame. Match the facial "
+    "expression exactly, frame by frame: preserve the exact degree of "
+    "mouth openness at every moment — if the mouth is slightly open and "
+    "still, keep it slightly open and still; do not close it, and do not "
+    "add talking or any mouth movement that is not in the source. Mirror "
+    "blinks, gaze direction, and eyebrow position at the same moments as "
+    "the source. Change only the visual style, nothing about the geometry, "
+    "composition, or performance."
+)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("video", nargs="?", default="finger-effect-raw.mp4")
+    ap.add_argument("-o", "--output", default="stylized.mp4")
+    ap.add_argument("-p", "--prompt", default=DEFAULT_PROMPT)
+    args = ap.parse_args()
+
+    if not (os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")):
+        sys.exit("Set GEMINI_API_KEY first — https://aistudio.google.com/apikey")
+    if not os.path.exists(args.video):
+        sys.exit(f"Input video not found: {args.video}")
+
+    from google import genai  # imported late so --help works without the dep
+
+    client = genai.Client()
+
+    print(f"Uploading {args.video} …")
+    video_file = client.files.upload(file=args.video)
+    while getattr(video_file, "state", "") and "PROCESS" in str(video_file.state):
+        time.sleep(3)
+        video_file = client.files.get(name=video_file.name)
+    print(f"Uploaded: {video_file.uri}")
+
+    print(f"Generating with {MODEL} (typically a few minutes) …")
+    interaction = client.interactions.create(
+        model=MODEL,
+        input=[
+            {"type": "document", "uri": video_file.uri},
+            {"type": "text", "text": args.prompt},
+        ],
+    )
+
+    # Poll if the interaction reports as still running.
+    waited = 0
+    while (
+        str(getattr(interaction, "status", "")).lower()
+        in ("pending", "in_progress", "processing", "running", "queued")
+        and waited < 900
+    ):
+        time.sleep(5)
+        waited += 5
+        interaction = client.interactions.get(id=interaction.id)
+        print(f"  … {waited}s ({interaction.status})")
+
+    video_out = getattr(interaction, "output_video", None)
+    if video_out is None:
+        sys.exit(f"No video in response — raw interaction:\n{interaction}")
+
+    data = getattr(video_out, "data", None)
+    if data:
+        import base64
+
+        with open(args.output, "wb") as f:
+            f.write(base64.b64decode(data) if isinstance(data, str) else data)
+    else:
+        uri = getattr(video_out, "uri", None)
+        if not uri:
+            sys.exit(f"No data or uri on output video:\n{video_out}")
+        name = "files/" + uri.split("/files/")[1].split("?")[0] if "/files/" in uri else uri
+        for _ in range(120):
+            f = client.files.get(name=name)
+            if "ACTIVE" in str(getattr(f, "state", "")):
+                break
+            time.sleep(5)
+        print("Downloading result …")
+        client.files.download(file=f, path=args.output) if hasattr(
+            client.files, "download"
+        ) else None
+        if not os.path.exists(args.output):
+            blob = client.files.download(file=f)
+            with open(args.output, "wb") as out:
+                out.write(blob)
+
+    print(f"Done: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/finger-frame-ai/scripts/test_process.py
+++ b/skills/finger-frame-ai/scripts/test_process.py
@@ -1,0 +1,138 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import process
+
+
+class ProcessTests(unittest.TestCase):
+    def test_default_output_uses_source_directory(self):
+        output = process.default_output(Path("/tmp/My Clip.MOV"))
+        self.assertEqual(output, Path("/tmp/My Clip-finger-frame.mp4"))
+
+    def test_resolve_video_rejects_missing_path(self):
+        with self.assertRaisesRegex(SystemExit, "Input video not found"):
+            process.resolve_video("/definitely/missing/video.mp4")
+
+    def test_resolve_api_key_prefers_gemini_key(self):
+        with mock.patch.dict(
+            os.environ,
+            {"GEMINI_API_KEY": "gemini-key", "GOOGLE_API_KEY": "google-key"},
+            clear=True,
+        ):
+            self.assertEqual(process.resolve_api_key(), "gemini-key")
+
+    def test_resolve_api_key_requires_env_when_headless(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(process.sys.stdin, "isatty", return_value=False),
+            self.assertRaisesRegex(SystemExit, "headless mode"),
+        ):
+            process.resolve_api_key()
+
+    def test_check_readiness_reports_missing_binary(self):
+        with mock.patch.object(
+            process.shutil,
+            "which",
+            side_effect=lambda command: None if command == "ffmpeg" else "/bin/ffprobe",
+        ):
+            self.assertFalse(process.check_readiness())
+
+    def test_prepare_upload_keeps_small_video(self):
+        with tempfile.TemporaryDirectory() as directory:
+            video = Path(directory) / "small.mp4"
+            video.write_bytes(b"small")
+            self.assertEqual(
+                process.prepare_upload(video, Path(directory), 15), (video, False)
+            )
+
+    def test_prepare_upload_compresses_large_video(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            video = root / "large.mov"
+            video.write_bytes(b"x" * 101)
+            working = root / "large-working-720p.mp4"
+
+            def create_working(*args, **kwargs):
+                working.write_bytes(b"x" * 80)
+
+            with (
+                mock.patch.object(process, "probe_duration", return_value=10),
+                mock.patch.object(
+                    process, "run_command", side_effect=create_working
+                ) as run,
+            ):
+                result = process.prepare_upload(video, root, 0.0001)
+
+        self.assertEqual(result, (working, True))
+        self.assertIn("ffmpeg", run.call_args.args[0])
+        self.assertIn("scale=-2:720", run.call_args.args[0])
+
+    def test_main_rejects_source_as_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            video = Path(directory) / "input.mp4"
+            video.touch()
+            args = mock.Mock(
+                check=False,
+                video=str(video),
+                output=str(video),
+                prompt=None,
+                keep_stylized=False,
+                max_upload_mb=15,
+            )
+            with (
+                mock.patch.object(
+                    process,
+                    "build_parser",
+                    return_value=mock.Mock(parse_args=mock.Mock(return_value=args)),
+                ),
+                mock.patch.object(process.shutil, "which", return_value="/usr/bin/tool"),
+                mock.patch.object(process, "ensure_environment"),
+                mock.patch.object(process, "resolve_api_key", return_value="secret"),
+                self.assertRaisesRegex(SystemExit, "different from the source"),
+            ):
+                process.main()
+
+    def test_main_runs_both_stages_and_removes_intermediate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            video = root / "input.mp4"
+            video.touch()
+            output = root / "final.mp4"
+            stylized = root / "final-stylized.mp4"
+            stylized.touch()
+
+            args = mock.Mock(
+                check=False,
+                video=str(video),
+                output=str(output),
+                prompt="anime",
+                keep_stylized=False,
+                max_upload_mb=15,
+            )
+            with (
+                mock.patch.object(
+                    process,
+                    "build_parser",
+                    return_value=mock.Mock(parse_args=mock.Mock(return_value=args)),
+                ),
+                mock.patch.object(process.shutil, "which", return_value="/usr/bin/tool"),
+                mock.patch.object(process, "ensure_environment"),
+                mock.patch.object(process, "resolve_api_key", return_value="secret"),
+                mock.patch.object(
+                    process, "prepare_upload", return_value=(video, False)
+                ),
+                mock.patch.object(process, "run_command") as run,
+            ):
+                process.main()
+
+            self.assertEqual(run.call_count, 2)
+            self.assertIn("--prompt", run.call_args_list[0].args[0])
+            self.assertFalse(stylized.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR

Add `finger-frame-ai` to the core skills marketplace so AdaL users can turn a local two-hand finger-frame clip into an AI-stylized composite with one guided workflow.

## What changed

### Skill workflow

- Adds trigger guidance and a safe agent workflow in `skills/finger-frame-ai/SKILL.md`.
- Requests an absolute local video path when needed.
- Requires confirmation before the potentially paid Gemini Omni call.
- Keeps API keys out of chat, command arguments, logs, and the repository.
- Verifies the final artifact with FFmpeg/ffprobe before reporting success.

### Bundled video pipeline

- Creates/reuses an isolated virtual environment.
- Installs bundled Python requirements when missing.
- Adds a non-destructive `--check` readiness mode.
- Automatically compresses sources over 15 MB to a temporary 720p upload copy.
- Restyles the source timeline with `gemini-omni-flash-preview`.
- Tracks the two-hand frame with MediaPipe.
- Composites the stylized clip inside the tracked quadrilateral and preserves audio.
- Prevents output from overwriting the source and cleans up temporary media.

### Marketplace

- Registers `./skills/finger-frame-ai` under `core-skills`.
- Adds the skill to the repository README.
- Credits the originating `sophiamyang/finger-frame-effect-ai` project.

## Testing

- `python3 -m unittest discover -s skills/finger-frame-ai/scripts -p 'test_*.py' -v` — 9 tests pass.
- Python compilation checks pass for all bundled scripts.
- `process.py --check` passes on a machine with FFmpeg/ffprobe.
- Marketplace JSON parses and includes the new registration.
- Full local MediaPipe/FFmpeg composite regression passes against an existing 720p fixture:
  - H.264 video
  - AAC audio
  - 18.23 seconds
- Cached diff passes whitespace, credential, generated-artifact, and debug scans.

## Intentional requirements

- Gemini video generation requires a locally configured `GEMINI_API_KEY` or `GOOGLE_API_KEY` with Omni access and quota.
- Gemini generation is not exercised by automated tests because it is paid, asynchronous, and quota-dependent.
- FFmpeg and ffprobe must already be available on `PATH`; the skill does not attempt privileged system installation.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
