### PR TITLE
fix: require interactions-capable google-genai

### DIFF
--- a/skills/finger-frame-ai/scripts/process.py
+++ b/skills/finger-frame-ai/scripts/process.py
@@ -34,8 +34,11 @@ def dependencies_available():
         import cv2  # noqa: F401
         import mediapipe  # noqa: F401
         import numpy  # noqa: F401
-        from google import genai  # noqa: F401
-    except ImportError:
+        from google import genai
+
+        if not hasattr(genai.Client, "interactions"):
+            return False
+    except (ImportError, TypeError):
         return False
     return True
 
@@ -51,7 +54,14 @@ def ensure_environment():
         run_command([sys.executable, "-m", "venv", VENV_DIR])
 
     check = subprocess.run(
-        [str(python), "-c", "import cv2, mediapipe, numpy; from google import genai"],
+        [
+            str(python),
+            "-c",
+            (
+                "import cv2, mediapipe, numpy; from google import genai; "
+                "assert hasattr(genai.Client, 'interactions')"
+            ),
+        ],
         capture_output=True,
     )
     if check.returncode != 0:

--- a/skills/finger-frame-ai/scripts/requirements.txt
+++ b/skills/finger-frame-ai/scripts/requirements.txt
@@ -1,4 +1,4 @@
 mediapipe>=0.10.14
 opencv-python>=4.9
 numpy>=1.26
-google-genai>=1.0
+google-genai>=2.3.0

--- a/skills/finger-frame-ai/scripts/stylize.py
+++ b/skills/finger-frame-ai/scripts/stylize.py
@@ -52,6 +52,11 @@ def main():
     from google import genai  # imported late so --help works without the dep
 
     client = genai.Client()
+    if not hasattr(client, "interactions"):
+        sys.exit(
+            "Gemini Omni requires google-genai>=2.3.0. Upgrade with: "
+            "python -m pip install --upgrade 'google-genai>=2.3.0'"
+        )
 
     print(f"Uploading {args.video} …")
     video_file = client.files.upload(file=args.video)

--- a/skills/finger-frame-ai/scripts/test_process.py
+++ b/skills/finger-frame-ai/scripts/test_process.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import subprocess
 import tempfile
+import types
 import unittest
 from unittest import mock
 
@@ -40,6 +41,72 @@ class ProcessTests(unittest.TestCase):
             side_effect=lambda command: None if command == "ffmpeg" else "/bin/ffprobe",
         ):
             self.assertFalse(process.check_readiness())
+
+    def test_dependencies_reject_client_without_interactions(self):
+        google = types.ModuleType("google")
+        google.genai = types.SimpleNamespace(Client=type("Client", (), {}))
+        modules = {
+            "cv2": types.ModuleType("cv2"),
+            "mediapipe": types.ModuleType("mediapipe"),
+            "numpy": types.ModuleType("numpy"),
+            "google": google,
+        }
+        with mock.patch.dict(process.sys.modules, modules):
+            self.assertFalse(process.dependencies_available())
+
+    def test_dependencies_accept_client_with_interactions(self):
+        google = types.ModuleType("google")
+        google.genai = types.SimpleNamespace(
+            Client=type("Client", (), {"interactions": property(lambda self: None)})
+        )
+        modules = {
+            "cv2": types.ModuleType("cv2"),
+            "mediapipe": types.ModuleType("mediapipe"),
+            "numpy": types.ModuleType("numpy"),
+            "google": google,
+        }
+        with mock.patch.dict(process.sys.modules, modules):
+            self.assertTrue(process.dependencies_available())
+
+    def test_environment_probe_checks_interactions_capability(self):
+        with (
+            mock.patch.object(
+                process, "venv_python", return_value=Path(process.sys.executable)
+            ),
+            mock.patch.object(process.subprocess, "run") as run,
+            mock.patch.object(process.os, "execve", side_effect=RuntimeError("stop")),
+            self.assertRaisesRegex(RuntimeError, "stop"),
+        ):
+            run.return_value.returncode = 0
+            process.ensure_environment()
+
+        probe = run.call_args.args[0]
+        self.assertIn("hasattr", probe[2])
+        self.assertIn("interactions", probe[2])
+
+    def test_failed_capability_probe_installs_requirements(self):
+        with (
+            mock.patch.object(
+                process, "venv_python", return_value=Path(process.sys.executable)
+            ),
+            mock.patch.object(process.subprocess, "run") as run,
+            mock.patch.object(process, "run_command") as install,
+            mock.patch.object(process.os, "execve", side_effect=RuntimeError("stop")),
+            self.assertRaisesRegex(RuntimeError, "stop"),
+        ):
+            run.return_value.returncode = 1
+            process.ensure_environment()
+
+        install.assert_called_once_with(
+            [
+                Path(process.sys.executable),
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                process.REQUIREMENTS,
+            ]
+        )
 
     def test_prepare_upload_keeps_small_video(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## TL;DR

Fix `finger-frame-ai` failing with:

```text
AttributeError: 'Client' object has no attribute 'interactions'
```

The skill allowed `google-genai>=1.0`, so environments with 1.47.0 passed the import check even though that SDK does not expose the Interactions API required by Gemini Omni.

## Root cause

Gemini Omni video editing uses:

```python
client.interactions.create(...)
interaction.output_video
```

Official SDK evidence:

- `google-genai==1.47.0` has no `Client.interactions`.
- `Client.interactions` is present in 2.x.
- `interaction.output_video`, which this skill also consumes, was added in 2.3.0.
- Google's current Omni documentation uses this same Interactions API flow.

Docs: https://ai.google.dev/gemini-api/docs/omni  
SDK release: https://github.com/googleapis/python-genai/releases/tag/v2.3.0

## Fix

- Raise the bundled requirement to `google-genai>=2.3.0`.
- Verify `genai.Client.interactions` in both dependency checks.
- Treat an existing stale `.venv` as incompatible and run the requirements upgrade automatically.
- Add a clear direct-run error in `stylize.py` with the upgrade command.
- Add regression tests for legacy and compatible SDK surfaces and stale-environment repair.

The actual `client.interactions.create(...)` request is unchanged because it already matches Google's supported Gemini Omni video-editing API.

## Testing

- 13 unit tests pass.
- Python compilation passes for all bundled scripts.
- Capability check verified directly against the official `google-genai==2.3.0` wheel.
- `pip --dry-run` resolves the updated requirements.
- Diff and credential scans pass.
- No Gemini request or paid generation was run for this fix.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
