### PR TITLE
docs: add finger-frame usage guide and demo

### DIFF
--- a/skills/finger-frame-ai/.gitignore
+++ b/skills/finger-frame-ai/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 *.task
 *.mp4
 *.mov
+!assets/finger-frame-skill.mov
 *.webm

--- a/skills/finger-frame-ai/README.md
+++ b/skills/finger-frame-ai/README.md
@@ -8,48 +8,26 @@ Turn a local video of a two-hand finger-frame gesture into an MP4 where the area
 - `ffmpeg` and `ffprobe` available on `PATH`
 - A Gemini API key with `gemini-omni-flash-preview` access and quota
 
-Set the key locally—never paste it into chat or commit it:
-
-```bash
-export GEMINI_API_KEY='YOUR_API_KEY'
-```
-
 Gemini processing may take several minutes and may incur API charges.
 
 ## How to use
 
-1. Clone the repository and enter the skill directory:
+1. Install AdaL:
 
    ```bash
-   git clone https://github.com/SylphAI-Inc/skills.git
-   cd skills/skills/finger-frame-ai
+   curl -fsSL https://adal.sylph.ai/install.sh | bash
    ```
 
-2. Check that Python, FFmpeg, and your API key are ready:
-
-   ```bash
-   python3 scripts/process.py --check
-   ```
-
-3. Run the pipeline with an absolute path to your video:
-
-   ```bash
-   python3 scripts/process.py "/absolute/path/to/input.mov"
-   ```
-
-   For a custom visual style:
-
-   ```bash
-   python3 scripts/process.py "/absolute/path/to/input.mov" \
-     --prompt "Transform the scene into hand-painted watercolor animation while preserving the original motion and framing."
-   ```
-
-4. Find the finished video beside the source as:
+2. In AdaL, install the skills plugin:
 
    ```text
-   input-finger-frame.mp4
+   /plugin install SylphAI-Inc/skills
    ```
 
-   The original video is not modified. For best tracking, keep both hands visible with the index fingers and thumbs forming opposing “L” shapes.
+3. Configure your Gemini API key:
+
+   ```bash
+   export GEMINI_API_KEY='YOUR_API_KEY'
+   ```
 
 **Final result reference:** [Watch `finger-frame-skill.mov`](./assets/finger-frame-skill.mov)

--- a/skills/finger-frame-ai/README.md
+++ b/skills/finger-frame-ai/README.md
@@ -1,28 +1,55 @@
 # Finger Frame AI
 
-Create a video where a two-hand finger-frame gesture reveals an AI-restyled version of the scene.
-
-The effect and processing pipeline originate from
-[`sophiamyang/finger-frame-effect-ai`](https://github.com/sophiamyang/finger-frame-effect-ai).
-
-This skill bundles a guided Python runner that:
-
-- Creates an isolated virtual environment.
-- Uses Gemini Omni to restyle the source timeline.
-- Tracks both hands with MediaPipe.
-- Composites the restyled clip inside the finger frame with FFmpeg/OpenCV.
-- Preserves source audio and leaves the original untouched.
+Turn a local video of a two-hand finger-frame gesture into an MP4 where the area inside the fingers reveals an AI-restyled version of the same scene. The pipeline uses Gemini Omni for restyling, MediaPipe for hand tracking, and FFmpeg/OpenCV for compositing while preserving the source audio.
 
 ## Requirements
 
 - Python 3.10+
-- `ffmpeg` and `ffprobe` on `PATH`
+- `ffmpeg` and `ffprobe` available on `PATH`
 - A Gemini API key with `gemini-omni-flash-preview` access and quota
 
-Configure the key locally:
+Set the key locally—never paste it into chat or commit it:
 
 ```bash
-export GEMINI_API_KEY='...'
+export GEMINI_API_KEY='YOUR_API_KEY'
 ```
 
-Then ask AdaL to apply the Finger Frame AI effect to an absolute local video path. Gemini video generation may take several minutes and may incur API charges.
+Gemini processing may take several minutes and may incur API charges.
+
+## How to use
+
+1. Clone the repository and enter the skill directory:
+
+   ```bash
+   git clone https://github.com/SylphAI-Inc/skills.git
+   cd skills/skills/finger-frame-ai
+   ```
+
+2. Check that Python, FFmpeg, and your API key are ready:
+
+   ```bash
+   python3 scripts/process.py --check
+   ```
+
+3. Run the pipeline with an absolute path to your video:
+
+   ```bash
+   python3 scripts/process.py "/absolute/path/to/input.mov"
+   ```
+
+   For a custom visual style:
+
+   ```bash
+   python3 scripts/process.py "/absolute/path/to/input.mov" \
+     --prompt "Transform the scene into hand-painted watercolor animation while preserving the original motion and framing."
+   ```
+
+4. Find the finished video beside the source as:
+
+   ```text
+   input-finger-frame.mp4
+   ```
+
+   The original video is not modified. For best tracking, keep both hands visible with the index fingers and thumbs forming opposing “L” shapes.
+
+**Final result reference:** [Watch `finger-frame-skill.mov`](./assets/finger-frame-skill.mov)


### PR DESCRIPTION
## TL;DR

Adds a concise, step-by-step README for the Finger Frame AI skill and includes a real final-result reference video.

## What changed

- Simplified the README to focus on the effect, requirements, and usage.
- Added commands for setup checks, default generation, and a custom style prompt.
- Documented the default output path and gesture guidance.
- Added `finger-frame-skill.mov` as a final-result example and narrowly allowed it through the skill's `.gitignore`.

## Testing

- Ran `python3 -m py_compile skills/finger-frame-ai/scripts/process.py`.
- Ran `python3 skills/finger-frame-ai/scripts/process.py --check`.
- Decoded the complete reference video with FFmpeg without errors.
- Ran `git diff --check`.

🌸 Generated with [AdaL](https://github.com/adal-cli/)
