### PR TITLE
feat(finger-frame-ai): default to cyberpunk-styled finger-frame output

### DIFF
--- a/skills/finger-frame-ai/SKILL.md
+++ b/skills/finger-frame-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finger-frame-ai
-description: Generate a finished finger-frame effect video from a local clip using Gemini Omni restyling, MediaPipe hand tracking, and FFmpeg compositing. Use when someone asks to make, create, restyle, or process a video where a two-hand finger-frame becomes a window into an AI-stylized world.
+description: Generate a finished cyberpunk-styled finger-frame effect video from a local clip using Gemini Omni restyling, MediaPipe hand tracking, and FFmpeg compositing. Use when someone asks to make, create, restyle, or process a video where a two-hand finger-frame becomes a window into an AI-stylized (default: neon cyberpunk CGI) world.
 author: shangliy
 version: 1.0.0
 ---
@@ -59,7 +59,7 @@ Short clips are faster and cheaper. Sources larger than 15 MB are automatically 
 
 ### 3. Generate
 
-Default 3D animated-movie style:
+Default cyberpunk-styled 3D animated-movie look:
 
 ```bash
 python3 <skill>/scripts/process.py "/absolute/path/to/input.mov"

--- a/skills/finger-frame-ai/scripts/stylize.py
+++ b/skills/finger-frame-ai/scripts/stylize.py
@@ -19,10 +19,14 @@ import time
 
 MODEL = "gemini-omni-flash-preview"
 DEFAULT_PROMPT = (
-    "Transform the person into a 3D animated movie character (stylized CGI "
-    "animation look, expressive big eyes, soft lighting). This is a strict "
-    "pixel-aligned edit of the source video: keep the same pose, motion, "
-    "timing, clothing colors, and background. The camera must not change — "
+    "Transform the person in the video into a 3D animated movie character "
+    "with a stylized CGI animation look, featuring expressive big eyes and "
+    "vibrant cyberpunk lighting. The background should be futuristic and "
+    "colorful, using neon pink, blue, and other vivid sci-fi tones, with "
+    "dramatic lighting that creates a strong contrast with the original "
+    "video. This is a strict pixel-aligned edit of the source video: keep "
+    "the same pose, motion, timing, clothing colors, and background. The "
+    "camera must not change — "
     "no zoom, no crop, no recentering, and no change to the field of view. "
     "The person's face and body must stay at exactly the same position and "
     "size in the frame as the source: eyes, nose, and mouth must remain at "


### PR DESCRIPTION
## TL;DR
Change the `finger-frame-ai` skill's default restyle look from a plain 3D-animated-movie style to a cyberpunk-themed 3D CGI style (big expressive eyes + neon pink/blue sci-fi lighting), based on results validated across several real user clips.

## What changed
- `scripts/stylize.py`: Updated `DEFAULT_PROMPT` to describe a cyberpunk aesthetic (futuristic, colorful neon pink/blue/vivid sci-fi tones, dramatic lighting) while preserving all existing pixel-alignment constraints (pose, motion, timing, camera, facial expression lock).
- `SKILL.md`: Updated the skill description and the "Default … style" doc line to reflect the new cyberpunk default.

## Why
The plain 3D-animated-movie default produced a flat/soft background. Testing the cyberpunk prompt across multiple source clips (finger-frame demo videos) consistently produced a punchier, more "fancy" background users specifically asked for, without breaking pixel alignment or facial expression fidelity.

## Testing
Ran the full pipeline (`process.py`) end-to-end with the new default prompt-equivalent text on 4 separate source videos (varying resolution/duration/orientation). All completed successfully; verified each output with `ffprobe` (H.264/AAC, correct duration/resolution, non-empty). MediaPipe hand tracking correctly located the finger-frame window in every case.

## Intentional TODOs
- None. Custom `--prompt` override still works unchanged for users who want a different style.
